### PR TITLE
Adds documentation for node GET /shipments

### DIFF
--- a/_includes/navs/reference_nav.html
+++ b/_includes/navs/reference_nav.html
@@ -7,6 +7,7 @@
       <a href="#shipments">Shipments</a>
       <ul class="nav">
         <li><a href="#creating-a-shipment">Create</a></li>
+        <li><a href="#getting-a-list-of-shipments">Index</a></li>
         <li><a href="#getting-information-about-a-shipment">Read</a></li>
         <li><a href="#updating-a-shipment">Update</a></li>
         <li><a href="#deleting-a-shipment">Delete</a></li>

--- a/_includes/shipments_index_response.json
+++ b/_includes/shipments_index_response.json
@@ -1,0 +1,95 @@
+{
+  "shipments": [{
+    "id": "86afb143f9c9c0cfd4eb7a7c26a5c616585a6271",
+    "carrier_tracking_no": "43128000105",
+    "carrier": "hermes",
+    "service": "standard",
+    "created_at": "2014-11-12T14:03:45+01:00",
+    "price": 3.5,
+    "reference_number": null,
+    "tracking_url": "http://track.shipcloud.dev/de/86afb143f9",
+    "to": {
+      "company": null,
+      "first_name": "Hans",
+      "last_name": "Meier",
+      "care_of": null,
+      "street": "Semmelweg",
+      "street_no": "1",
+      "zip_code": "12345",
+      "city": "Hamburg",
+      "state": null,
+      "country": "Germany"
+    },
+    "from": {
+      "company": "webionate GmbH",
+      "first_name": null,
+      "last_name": "Fahlbusch",
+      "care_of": null,
+      "street": "Lüdmoor",
+      "street_no": "35a",
+      "zip_code": "22175",
+      "city": "Hamburg",
+      "state": null,
+      "country": "Germany"
+    },
+    "packages": [{
+      "id": "be81573799958587ae891b983aabf9c4089fc462",
+      "length": 10.0,
+      "width": 10.0,
+      "height": 10.0,
+      "weight": 1.5,
+      "tracking_events": [{
+        "timestamp": "2014-11-12T14:03:45+01:00",
+        "location": "shipcloud",
+        "status": "shipcloud_label_created",
+        "details": "Es wurde eine Sendung angelegt"
+      }]
+    }]
+  }, {
+    "id": "be598a2fd27304cf2d82669b197517623629d94e",
+    "carrier_tracking_no": "1Z12345E1305277940",
+    "carrier": "ups",
+    "service": "standard",
+    "created_at": "2014-11-12T14:03:45+01:00",
+    "price": 3.0,
+    "reference_number": null,
+    "tracking_url": "http://track.shipcloud.dev/de/be598a2fd2",
+    "to": {
+      "company": null,
+      "first_name": "Test",
+      "last_name": "Kunde",
+      "care_of": null,
+      "street": "Gluckstr.",
+      "street_no": "57",
+      "zip_code": "22081",
+      "city": "Hamburg",
+      "state": null,
+      "country": "Germany"
+    },
+    "from": {
+      "company": "webionate GmbH",
+      "first_name": null,
+      "last_name": "Fahlbusch",
+      "care_of": null,
+      "street": "Lüdmoor",
+      "street_no": "35a",
+      "zip_code": "22175",
+      "city": "Hamburg",
+      "state": null,
+      "country": "Germany"
+    },
+    "packages": [{
+      "id": "74d4f1fc193d8a7ca542d1ee4e2021f3ddb82242",
+      "length": 15.0,
+      "width": 20.0,
+      "height": 10.0,
+      "weight": 2.0,
+      "tracking_events": [{
+        "timestamp": "2014-11-12T14:03:45+01:00",
+        "location": "shipcloud",
+        "status": "shipcloud_label_created",
+        "details": "Es wurde eine Sendung angelegt"
+      }]
+    }]
+  }]
+}

--- a/reference/index.md
+++ b/reference/index.md
@@ -36,6 +36,32 @@ If you want to create a shipment, this is the way to go!
 
 <i class="glyphicon glyphicon-arrow-right"></i> JSON schema: [Shipments response]({{ site.baseurl }}/reference/shipments_response_schema.html)
 
+### Getting a list of shipments
+
+#### Request
+<kbd>GET</kbd> __/v1/shipments__
+{% highlight json %}
+no payload
+{% endhighlight %}
+
+You can filter the shipments list using one or more of the following
+
+__GET parameters:__
+
+- __carrier__, e.g. 'carrier=dhl'
+- __service__, e.g. 'service=returns'
+- __reference_number__, e.g. 'reference_number=ref123456'
+- __carrier_tracking_no__, e.g. 'carrier_tracking_no=43128000105'
+- __tracking_status__, e.g. 'tracking_status=out_for_delivery'
+- __page__, show page number x, e.g. 'page=2'
+- __per_page__, show x number of shipments on a page (default: 100), e.g. 'per_page=25'
+
+#### Response
+{% include headers/200_ok.html %}
+{% highlight json %}
+{% include shipments_index_response.json %}
+{% endhighlight %}
+
 ### Getting information about a shipment
 <p class="bg-info">
   <i class="glyphicon glyphicon-info-sign"></i>


### PR DESCRIPTION
The API now provides access to the authenticated user's list of shipments,
allowing basic filtering and paging via HTTP query parameters.

This PR adds basic documentation for this node.