### PR TITLE
adding a curl sample for dpd drop authorization

### DIFF
--- a/_includes/samples/curl.html
+++ b/_includes/samples/curl.html
@@ -109,5 +109,37 @@ curl -u {{ site.apikey }}: https://api.shipcloud.io/v1/rates \
     {% highlight bash %}
       curl -u {{ site.apikey }}: https://api.shipcloud.io/v1/carriers
     {% endhighlight %}
+    <h3>Creating a new shipment with DPD drop authorization</h3>
+    <p>
+      When sending packages via DPD the sender can allow the carrier to leave
+      the shipment with someone else in case the receiver isn't present and has
+      allowed the sender to do so.
+    </p>
+{% highlight bash %}
+curl -u {{ site.apikey }}: https://api.shipcloud.io/v1/shipments \
+  -d "to[first_name]=Max" \
+  -d "to[last_name]=Mustermann" \
+  -d "to[company]=webionate GmbH" \
+  -d "to[street]=Mittelweg" \
+  -d "to[street_no]=158a" \
+  -d "to[city]=Hamburg" \
+  -d "to[zip_code]=20148" \
+  -d "to[country]=DE" \
+  -d "from[company]=shipcloud GmbH" \
+  -d "from[last_name]=Fahlbusch" \
+  -d "from[street]=Lüdmoor" \
+  -d "from[street_no]=35A" \
+  -d "from[city]=Hamburg" \
+  -d "from[zip_code]=22175" \
+  -d "from[country]=DE" \
+  -d "carrier=dpd" \
+  -d "package[weight]=1.5" \
+  -d "package[length]=10" \
+  -d "package[width]=6" \
+  -d "package[height]=8" \
+  -d "additional_services[][name]=drop_authorization" \
+  -d "additional_services[][properties][message]=the drop message" \
+  -d "create_shipping_label=true"
+{% endhighlight %}
   </div>
 </div>


### PR DESCRIPTION
This pull request adds a curl example for specifying drop authorization when using dpd as carrier