### PR TITLE
Remove GLS from the list of carriers that support pickup requests

### DIFF
--- a/reference/index.md
+++ b/reference/index.md
@@ -302,7 +302,7 @@ With this you're requesting pickup of packages for a specific carrier
 
 __Parameters:__
 
-- __carrier__ (string), the carrier you want to use. Possible values are "dhl", "gls", "fedex", "hermes", "ups".
+- __carrier__ (string), the carrier you want to use. Possible values are "dhl", "fedex", "hermes", "ups".
 - __pickup_date__ (string), pickup date (e.g. 2014/02/12)
 - __shipments__ (array of shipment objects), if you want only specific shipments to get picked up, you can send their shipment objects with the request. Please keep in mind that only normal and no return shipments can be picked up.
 


### PR DESCRIPTION
We do not (as of now) support pickup requests for the carrier GLS - so we shouldn't mention GLS here.