### PR TITLE
added a tiny info about timeouts

### DIFF
--- a/_includes/navs/concepts_nav.html
+++ b/_includes/navs/concepts_nav.html
@@ -9,6 +9,7 @@
         <li><a href="#versioning">Versioning</a></li>
         <li><a href="#address-handling">Address handling</a></li>
         <li><a href="#metadata">Metadata</a></li>
+        <li><a href="#timeouts">Timeouts</a></li>
       </ul>
     </li>
     <li>

--- a/concepts/index.md
+++ b/concepts/index.md
@@ -110,6 +110,12 @@ POST /shipments
 }
 {% endhighlight %}
 
+## Timeouts
+The services of the carriers we're supporting can be very slow at times. Since we're not queing
+requests to create shipping labels at a later point in time, please account for slow response
+times. We'd suggest setting a timeout of a little more than a minute to be absolutely sure that
+you're not missing our responses.
+
 # Carrier specifics
 
 ## Carrier specific address handling


### PR DESCRIPTION
since the carrier web services can be slow from time to time we nee to be specific about timeouts when using the shipcloud api