### PR TITLE
Fix param name for package type

### DIFF
--- a/_includes/reference/shipments_request_parameters.md
+++ b/_includes/reference/shipments_request_parameters.md
@@ -22,7 +22,7 @@ __Parameters:__
     - __amount__ (float), value of package contents
     - __currency__ (string), currency as uppercase ISO 4217 code
   - __description__ (string), if you're using UPS with service _returns_ or DHL with service _express_ this is mandatory otherwise it's optional
-  - __package_type__ (string, optional), carrier specific package type declaration. Available values are "bulk" and "parcel_letter"
+  - __type__ (string, optional), carrier specific package type declaration. Available values are "bulk" and "parcel_letter"
 - __service__ (string, optional), additional service. Available values are "returns", "standard", "one_day" (Express),"one_day_early" (Express until 10 o'clock). default: standard
 - __reference_number__ (string, optional), a reference number (max. 30 characters) that you want this shipment to be identified with. You can use this afterwards to easier find the shipment in the shipcloud.io backoffice
 - __description__ (string), mandatory if you're using UPS and the following conditions are true: from and to countries are not the same; from and/or to countries are not in the EU; from and to countries are in the EU and the shipments service is not standard

--- a/_includes/schemas/shipments_request.json
+++ b/_includes/schemas/shipments_request.json
@@ -121,7 +121,7 @@
           "type": "string",
           "description": "text that describes the contents of the package. This parameter is mandatory if you're using UPS with service returns or DHL with service express"
         },
-        "package_type": {
+        "type": {
           "type": "string",
           "enum": ["bulk", "parcel_letter"],
           "description": "defines packages of being of a certain type"

--- a/recipes/index.md
+++ b/recipes/index.md
@@ -92,7 +92,7 @@ of your package.
 
 __Requirements:__
 
-- <code>package_type</code> has to be _'bulk'_
+- <code>type</code> has to be _'bulk'_
 - you'll have to use your own contract with the carrier
 
 {% highlight http %}
@@ -109,7 +109,7 @@ POST https://api.shipcloud.io/v1/shipments
   },
   "package": {
     "weight": 5.5,
-    "package_type": "bulk"
+    "type": "bulk"
   },
   "carrier": "dhl",
   "create_shipping_label": true
@@ -122,7 +122,7 @@ as "everything which is too small for a parcel but larger and heavier than a cla
 
 __Requirements:__
 
-- <code>package_type</code> has to be _'parcel_letter'_
+- <code>type</code> has to be _'parcel_letter'_
 
 {% highlight http %}
 POST https://api.shipcloud.io/v1/shipments
@@ -141,7 +141,7 @@ POST https://api.shipcloud.io/v1/shipments
     "length": 25,
     "width": 36,
     "height": 5,
-    "package_type": "parcel_letter"
+    "type": "parcel_letter"
   },
   "carrier": "dpd",
   "service": "standard",


### PR DESCRIPTION
When creating a shipment with a package that has a type, the proper param name is type and not package_type.