### PR TITLE
added information about label sizes

### DIFF
--- a/_includes/concepts/carrier_specific_label_sizes.html
+++ b/_includes/concepts/carrier_specific_label_sizes.html
@@ -1,0 +1,88 @@
+<div class="row">
+  <div class="col-md-12">
+    <table class="table services">
+      <thead>
+        <tr>
+          <th>&nbsp;</th>
+          <th>
+            <img class="carrier-logo--table-header" src="{{site.baseurl}}/assets/images/logos/carriers/ups.png" title="UPS" alt="UPS" />
+          </th>
+          <th>
+            <img class="carrier-logo--table-header" src="{{site.baseurl}}/assets/images/logos/carriers/dhl.png" title="DHL" alt="DHL" />
+          </th>
+          <th>
+            <img class="carrier-logo--table-header" src="{{site.baseurl}}/assets/images/logos/carriers/hermes.png" title="Hermes" alt="Hermes" />
+          </th>
+          <th>
+            <img class="carrier-logo--table-header" src="{{site.baseurl}}/assets/images/logos/carriers/gls.png" title="GLS" alt="GLS" />
+          </th>
+          <th>
+            <img class="carrier-logo--table-header" src="{{site.baseurl}}/assets/images/logos/carriers/dpd.png" title="DPD" alt="DPD" />
+          </th>
+          <th>MyDPD<br />Business<sup>*</sup></th>
+          <th>FedEx</th>
+          <th>
+            <img class="carrier-logo--table-header" src="{{site.baseurl}}/assets/images/logos/carriers/liefery.png" title="Liefery" alt="Liefery" />
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>standard</td>
+          <td>A5 / A6</td>
+          <td>A5 / A6</td>
+          <td>A5</td>
+          <td>A5 / A6</td>
+          <td>A5 / A6</td>
+          <td>A5 / A6</td>
+          <td>-</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>one_day</td>
+          <td>A5 / A6</td>
+          <td>A5</td>
+          <td>-</td>
+          <td>A5 / A6</td>
+          <td>A5 / A6</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>one_day_early</td>
+          <td>A5 / A6</td>
+          <td>A5</td>
+          <td>-</td>
+          <td>-</td>
+          <td>A5 / A6</td>
+          <td>-</td>
+          <td>A5</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>same_day</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+          <td>A5</td>
+        </tr>
+        <tr>
+          <td>returns</td>
+          <td>A5 / A6</td>
+          <td>A5</td>
+          <td>A5</td>
+          <td>-</td>
+          <td>A5 / A6</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/_includes/concepts/supported_services.html
+++ b/_includes/concepts/supported_services.html
@@ -75,7 +75,7 @@
             <div class="glyphicon glyphicon-ban-circle"></div>
           </td>
           <td>
-            <div class="glyphicon glyphicon-ok-circle"></div>
+            <div class="glyphicon glyphicon-ban-circle"></div>
           </td>
           <td>
             <div class="glyphicon glyphicon-ban-circle"></div>
@@ -93,7 +93,7 @@
             <div class="glyphicon glyphicon-ban-circle"></div>
           </td>
           <td>
-            <div class="glyphicon glyphicon-ok-circle"></div>
+            <div class="glyphicon glyphicon-ban-circle"></div>
           </td>
           <td>
             <div class="glyphicon glyphicon-ok-circle"></div>

--- a/_includes/navs/concepts_nav.html
+++ b/_includes/navs/concepts_nav.html
@@ -17,6 +17,7 @@
       <ul class="nav">
         <li><a href="#carrier-specific-address-handling">Carrier specific address handling</a></li>
         <li><a href="#carrier-specific-field-lengths">Carrier specific field lengths</a></li>
+        <li><a href="#carrier-specific-label-sizes">Carrier specific label sizes</a></li>
       </ul>
     </li>
     <li>

--- a/_includes/navs/recipes_nav.html
+++ b/_includes/navs/recipes_nav.html
@@ -1,5 +1,6 @@
 <div id="sub-nav" data-spy="affix">
   <ul class="nav">
+    <li><a href="#label-size">Label size</a></li>
     <li><a href="#dhl-packstation">DHL Packstation</a></li>
     <li><a href="#dhl-postfiliale">DHL Postfiliale</a></li>
     <li><a href="#dhl-higher-insurance">DHL higher insurance</a></li>

--- a/_includes/reference/shipments_request_parameters.md
+++ b/_includes/reference/shipments_request_parameters.md
@@ -16,5 +16,6 @@ __Parameters:__
 - __service__ (string, optional), service that should be used. Available values are "returns", "standard", "one_day" , "one_day_early". See [supported services]({{ site.baseurl }}/concepts/#supported-services) for detailed information
 - __reference_number__ (string, optional), a reference number (max. 30 characters) that you want this shipment to be identified with. You can use this afterwards to easier find the shipment in the shipcloud.io backoffice
 - __description__ (string), mandatory if you're using UPS and the following conditions are true: from and to countries are not the same; from and/or to countries are not in the EU; from and to countries are in the EU and the shipments service is not standard
+- __label__ (object, optional), define the DIN size the returned label should have. See [label size recipe]({{ site.baseurl }}/recipes/#label-size) for detailed information
 - __notification_email__ (string, optional), email address that we should notify once there's an update for this shipment
 - __create_shipping_label__ (boolean), determines if a shipping label should be created at the carrier (this means you will be charged when using the production api key)

--- a/_includes/schemas/shipments_request.json
+++ b/_includes/schemas/shipments_request.json
@@ -32,6 +32,10 @@
       "type": "string",
       "description": "text that describes the contents of the shipment. This parameter is mandatory if you're using UPS and the following conditions are true: from and to countries are not the same; from and/or to countries are not in the EU; from and to countries are in the EU and the shipments service is not standard"
     },
+    "label": {
+      "$ref": "#/definitions/label",
+      "description": "label characteristics"
+    },
     "notification_email": {
       "type": "string",
       "description": "email address that we should notify once there's an update for this shipment"
@@ -104,6 +108,17 @@
       },
       "required": ["last_name", "street", "street_no", "city", "zip_code", "country"],
       "additionalProperties": false
+    },
+    "label": {
+      "type": "object",
+      "properties": {
+        "size":  {
+          "type": "string",
+          "enum": ["A5", "A6"],
+          "description": "defines the DIN size that the returned label should have"
+      },
+      "additionalProperties": false,
+      "description": "label specific definitions"
     },
     "package": {
       "type": "object",

--- a/concepts/index.md
+++ b/concepts/index.md
@@ -155,6 +155,12 @@ correct according to the carrier.
 
 {% include concepts/carrier_specific_field_lengths_dpd.md %}
 
+## Carrier specific label sizes
+Each carrier can provide label sizes in a specific DIN format. Here's an overview of the label
+sizes that are available and can be configured within your shipcloud account:
+
+{% include concepts/carrier_specific_label_sizes.html %}
+
 # Supported services
 We currently support sending packages via the following carriers and services:
 

--- a/recipes/index.md
+++ b/recipes/index.md
@@ -9,6 +9,36 @@ To give you a better understanding of how the shipcloud api could be used you ca
 recipes on this page. Sometimes there's also a certain chain of calls you need to perform to
 achieve a specific goal.
 
+## Label size
+Not all carriers use the same size of labels. Have a look at our chart of the
+[carrier specific label sizes]({{ site.baseurl }}/concepts/#carrier-specific-label-sizes)
+we support.
+
+You can configure the standard size we should create labels for each and every carrier from within
+the shipcloud backoffice, so you won't have to think about handling different label sizes. You can
+however define the size of the label on a per shipment basis. So, when you're creating a shipping
+label via our api you can send us the size the shipping label should have.
+
+{% highlight javascript %}
+{
+  "from": {
+    // see [1]
+  },
+  "to": {
+    // see [1]
+  },
+  "package": {
+    // see [2]
+  },
+  "carrier": "dhl",
+  "service": "standard",
+  "label": {
+    "size": "A5"
+  },
+  "create_shipping_label": true
+}
+{% endhighlight %}
+
 ## DHL Packstation
 When sending to a DHL Packstation the following parameters have to be defined:
 


### PR DESCRIPTION
Every carrier allows shipping labels to have different sizes. To make things even more complicated, the size can be different based on the service that's being used. Therefore we're now documenting,which label sizes are available for each carrier and the specific service.

We also added information and definitions about how you can define the label size when creating a shipping label through the shipcloud api.