### PR TITLE
add pickup_address to PickupRequests

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -12,9 +12,15 @@ work with any other release modifiers than major versions.
 
 **Notice**: Not everything we do affects the viewable parts of our api.
 
+## [20160422] - 2016-04-22
+
+### Added
+- When making a PickupRequest you can now add a [pickup_address](https://developers.shipcloud.io/reference/#pickup-requests)
+  that tells the carrier where the shipments should be collected
+
 ## [20160304] - 2016-03-04
 
-### Fixed
+### Added
 - We're now returning [additional services](https://developers.shipcloud.io/recipes/#additional-services)
   when querying information about shipments
 

--- a/_includes/pickup_post_requests_request.json
+++ b/_includes/pickup_post_requests_request.json
@@ -4,6 +4,17 @@
     "earliest": "2015-09-15T09:00:00+02:00",
     "latest": "2015-09-15T18:00:00+02:00"
   },
+  "pickup_address": {
+    "company": "Muster-Company",
+    "first_name": "Max",
+    "last_name": "Mustermann",
+    "street": "Musterstraße",
+    "street_no": "42",
+    "zip_code": "54321",
+    "city": "Musterstadt",
+    "country": "DE",
+    "phone": "555-555"
+  },
   "shipments": [
     {
       "id": "3a186c51d4281acbecf5ed38805b1db92a9d668b"

--- a/_includes/pickup_post_requests_response.json
+++ b/_includes/pickup_post_requests_response.json
@@ -4,5 +4,17 @@
   "pickup_time": {
     "earliest": "2015-09-15T09:00:00+02:00",
     "latest": "2015-09-15T18:00:00+02:00"
+  },
+  "pickup_address": {
+    "id": "522a7cb1-d6c8-418c-ac26-011127ab5bbe",
+    "company": "Muster-Company",
+    "first_name": "Max",
+    "last_name": "Mustermann",
+    "street": "Musterstraße",
+    "street_no": "42",
+    "zip_code": "54321",
+    "city": "Musterstadt",
+    "country": "DE",
+    "phone": "555-555"
   }
 }

--- a/_includes/reference/pickup_requests_request_parameters.md
+++ b/_includes/reference/pickup_requests_request_parameters.md
@@ -1,9 +1,10 @@
 __Parameters:__
 
 - __carrier__ (string), the carrier you want to use. Possible values are "dpd", "fedex", "hermes", "ups".
-- __pickup_time__, object containing the earliest and latest pickup time in iso8601.
+- __pickup_time__ (object), contains the earliest and latest pickup time in iso8601.
   - __earliest__ (datetime), the date the shipments are ready for pickup.
   - __latest__ (datetime), the latest date for pick up.
-- __shipments__ (array of shipment objects), if you want only certain shipments to get picked up,
+- __pickup_address__ (object, optional), address where the carrier should pick up shipments. See [address request]({{ site.baseurl }}/reference/#addresses) for a detailed definition.
+- __shipments__ (array of shipment objects, optional), if you want only certain shipments to get picked up,
 you can send the specific shipment objects with the request. Please keep in mind that return
 shipments can't be picked up.

--- a/_includes/schemas/pickup_requests_request.json
+++ b/_includes/schemas/pickup_requests_request.json
@@ -23,6 +23,32 @@
       "required": ["earliest", "latest"],
       "additionalProperties": false
     },
+    "pickup_address": {
+      "type": "object",
+      "description": "address where the carrier should pick up shipments",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "identifier of a previously created address"
+        },
+        "company": { "type": "string" },
+        "first_name": { "type": "string" },
+        "last_name": { "type": "string" },
+        "care_of": { "type": "string" },
+        "street": { "type": "string" },
+        "street_no": { "type": "string" },
+        "city": { "type": "string" },
+        "zip_code": { "type": "string" },
+        "state": { "type": "string" },
+        "country": { "type": "string", "description": "Country as uppercase ISO 3166-1 alpha-2 code" },
+        "phone": {
+          "type": "string",
+          "description": "telephone number (mandatory when using UPS and the following terms apply: service is one_day or one_day_early or ship to country is different than ship from country)"
+        }
+      },
+      "required": ["last_name", "street", "street_no", "city", "zip_code", "country"],
+      "additionalProperties": false
+    },
     "pickup_date": {
       "type": "string",
       "pattern": "^[0-9]{4}\/[0-9]{2}\/[0-9]{2}$",

--- a/_includes/schemas/pickup_requests_response.json
+++ b/_includes/schemas/pickup_requests_response.json
@@ -26,6 +26,32 @@
       "required": ["earliest", "latest"],
       "additionalProperties": false
     },
+    "pickup_address": {
+      "type": "object",
+      "description": "address where the carrier should pick up shipments",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "identifier of a previously created address"
+        },
+        "company": { "type": "string" },
+        "first_name": { "type": "string" },
+        "last_name": { "type": "string" },
+        "care_of": { "type": "string" },
+        "street": { "type": "string" },
+        "street_no": { "type": "string" },
+        "city": { "type": "string" },
+        "zip_code": { "type": "string" },
+        "state": { "type": "string" },
+        "country": { "type": "string", "description": "Country as uppercase ISO 3166-1 alpha-2 code" },
+        "phone": {
+          "type": "string",
+          "description": "telephone number (mandatory when using UPS and the following terms apply: service is one_day or one_day_early or ship to country is different than ship from country)"
+        }
+      },
+      "required": ["last_name", "street", "street_no", "city", "zip_code", "country"],
+      "additionalProperties": false
+    },
   },
   "required": ["id", "carrier", "pickup_time"],
   "additionalProperties": false

--- a/reference/index.md
+++ b/reference/index.md
@@ -336,9 +336,11 @@ There are two ways you can request shipments to be picked up by a specific carri
 stating that all shipments that haven't been picked up already should be picked up or by specifying
 which shipments should by picked up.
 
-__Notice:__ _We're using the default from address that's being defined in the shipcloud profile
-for requesting a pickup by the carrier. Please keep in mind there are
-[carrier specific field lengths]({{ site.baseurl }}/concepts/#carrier-specific-field-lengths) for that._
+__Notice:__ _If you don't supply a pickup_address in your request, we're using the default from
+address that's being defined in the shipcloud profile for requesting a pickup by the carrier.
+Please keep in mind there are
+[carrier specific field lengths]({{ site.baseurl }}/concepts/#carrier-specific-field-lengths)
+for that._
 
 #### Request
 
@@ -354,6 +356,17 @@ Here's an example for having all shipments being picked up by a specific carrier
   "pickup_time": {
     "earliest": "2015-09-15T09:00:00+02:00",
     "latest": "2015-09-15T18:00:00+02:00"
+  },
+  "pickup_address": {
+    "company": "Muster-Company",
+    "first_name": "Max",
+    "last_name": "Mustermann",
+    "street": "Musterstraße",
+    "street_no": "42",
+    "zip_code": "54321",
+    "city": "Musterstadt",
+    "country": "DE",
+    "phone": "555-555"
   }
 }
 {% endhighlight %}
@@ -369,6 +382,10 @@ If you want to only have specific shipments be picked up you add the shipment id
 <i class="glyphicon glyphicon-arrow-right"></i> JSON schema: [Pickup Requests request]({{ site.baseurl }}/reference/pickup_requests_request_schema.html)
 
 #### Response
+
+__Notice:__ _Some carriers (e.g. Hermes) are using the address that's being defined at the carrier
+account for picking up shipments. In those cases we'll return ```null``` as pickup_address._
+
 {% include headers/200_ok.html %}
 {% highlight json %}
 {% include pickup_post_requests_response.json %}


### PR DESCRIPTION
We're now supporting a **pickup_address** to be defined when sending a PickupRequest. This way our customers can define where the carrier should pick up their packages.