### PR TITLE
be more clear about the use of the description parameters

### DIFF
--- a/_includes/navs/concepts_nav.html
+++ b/_includes/navs/concepts_nav.html
@@ -18,6 +18,7 @@
         <li><a href="#carrier-specific-address-handling">Carrier specific address handling</a></li>
         <li><a href="#carrier-specific-field-lengths">Carrier specific field lengths</a></li>
         <li><a href="#carrier-specific-label-sizes">Carrier specific label sizes</a></li>
+        <li><a href="#misc-carrier-specifics">Misc carrier specifics</a></li>
       </ul>
     </li>
     <li>

--- a/concepts/index.md
+++ b/concepts/index.md
@@ -161,6 +161,19 @@ sizes that are available and can be configured within your shipcloud account:
 
 {% include concepts/carrier_specific_label_sizes.html %}
 
+## Misc carrier specifics
+
+### DHL
+* when using the service ___one_day___ or ___one_day_early___ the parameter
+___package.description___ is mandatory
+
+### UPS
+* when using the service ___returns___ the parameter ___package.description___ is mandatory
+* if one of the following conditions is true, the parameter ___description___ is mandatory:
+  * from and to countries are not the same
+  * from and/or to countries are not in the EU
+  * from and to countries are in the EU and the shipments service is not ___standard___
+
 # Supported services
 We currently support sending packages via the following carriers and services:
 

--- a/reference/index.md
+++ b/reference/index.md
@@ -92,6 +92,12 @@ __GET parameters:__
 The following is a section of resources related to shipments. Be advised: We will charge you only for shipments that a
 label was created for.
 
+<p class="bg-info">
+  <i class="glyphicon glyphicon-info-sign"></i>
+  Please notice the requirements regarding the use of the parameter "description" (either in the
+  root or as part of the "package" attribute).
+</p>
+
 {% include reference/shipments_request_togglebox.html %}
 
 ### Creating a shipment


### PR DESCRIPTION
The use of the parameter _description_ leads to confusion a lot of times, since it is a carrier and service based combination, when to add it and when not.