### PR TITLE
be more specific about gls shipments and carrier numbers

### DIFF
--- a/_includes/schemas/shipments_response_reduced.json
+++ b/_includes/schemas/shipments_response_reduced.json
@@ -23,6 +23,6 @@
       "description": "price that we're going to charge you (exl. VAT)"
     }
   },
-  "required": ["id", "carrier_tracking_no", "tracking_url", "label_url", "price"],
+  "required": ["id", "tracking_url", "label_url", "price"],
   "additionalProperties": false
 }

--- a/concepts/index.md
+++ b/concepts/index.md
@@ -167,6 +167,11 @@ sizes that are available and can be configured within your shipcloud account:
 * when using the service ___one_day___ or ___one_day_early___ the parameter
 ___package.description___ is mandatory
 
+### GLS
+* shipments will receive a carrier tracking number (```carrier_tracking_no```) with the first scan
+by the carrier, which is why this parameter won't be included in the response when creating a
+shipment.
+
 ### UPS
 * when using the service ___returns___ the parameter ___package.description___ is mandatory
 * if one of the following conditions is true, the parameter ___description___ is mandatory:


### PR DESCRIPTION
Since GLS is creating a tracking number once the shipping label is scanned for the first time, we can't return it in our response, when a shipment for the carrier is being created.