### PR TITLE
adjusted value in examples for declared_value

### DIFF
--- a/_includes/recipes/declared_value_dhl.md
+++ b/_includes/recipes/declared_value_dhl.md
@@ -3,7 +3,7 @@
   "package": {
     // see packages [2]
     "declared_value": {
-       "amount": 123.45,
+       "amount": 555.45,
        "currency": "EUR"
      }
   }

--- a/_includes/shipments_post_put_request.json
+++ b/_includes/shipments_post_put_request.json
@@ -15,7 +15,7 @@
       "width": 20,
       "height": 20,
       "declared_value": {
-         "amount": 123.45,
+         "amount": 555.45,
          "currency": "EUR"
        }
   },


### PR DESCRIPTION
To be more clear about the amount when you can/should use declared_value when creating a shipment, I've adjusted the exmaples to show a value higher than 500 Euros.