### PR TITLE
document address handling for ShipmentQuotes

### DIFF
--- a/_includes/reference/shipment_quotes_request_parameters.md
+++ b/_includes/reference/shipment_quotes_request_parameters.md
@@ -1,9 +1,9 @@
 __Parameters:__
 
-- __carrier__* (string, required), the carrier you want to use. Possible values are "dpd", "dhl", "gls", "hermes", "iloxx", "ups", "fedex"
-- __service__ (string, required), service that should be used. Available values are "returns", "standard", "one_day" , "one_day_early". See [supported services]({{ site.baseurl }}/concepts/#supported-services) for detailed information
+- __carrier__* (string), the carrier you want to use. Possible values are "dpd", "dhl", "gls", "hermes", "iloxx", "ups", "fedex"
+- __service__ (string), service that should be used. Available values are "returns", "standard", "one_day" , "one_day_early", "same_day". See [supported services]({{ site.baseurl }}/concepts/#supported-services) for detailed information
 - __to__* (object), describes the receivers address. See [address request]({{ site.baseurl }}/reference/#addresses) for a detailed definition.
-- __from__* (object), describes the senders address. See [address request]({{ site.baseurl }}/reference/#addresses) for a detailed definition.
+- __from__ (object, optional), describes the senders address. See [address request]({{ site.baseurl }}/reference/#addresses) for a detailed definition.
 - __package__*, object describing the package dimensions
   - __width__ (float), width of the package in cm
   - __length__ (float), length of the package in cm

--- a/_includes/schemas/shipment_quotes_request.json
+++ b/_includes/schemas/shipment_quotes_request.json
@@ -25,7 +25,7 @@
       "$ref": "#/definitions/package"
     }
   },
-  "required": ["carrier", "service", "to", "from", "package"],
+  "required": ["carrier", "service", "to", "package"],
   "additionalProperties": false,
   "definitions": {
     "address": {

--- a/_includes/shipment_quotes_post_request_with_address_id.json
+++ b/_includes/shipment_quotes_post_request_with_address_id.json
@@ -2,11 +2,7 @@
   "carrier": "dhl",
   "service": "standard",
   "to": {
-    "street": "Beispielstrasse",
-    "street_no": "42",
-    "zip_code": "22100",
-    "city": "Hamburg",
-    "country": "DE"
+    "id": "522a7cb1-d6c8-418c-ac26-011127ab5bbe"
   },
   "from": {
     "street": "Musterstrasse",

--- a/reference/index.md
+++ b/reference/index.md
@@ -296,6 +296,16 @@ With this call you can find out how much we will charge you for a specific shipm
 {% include shipment_quotes_post_request.json %}
 {% endhighlight %}
 
+In case you've previously added an adress and know its ```id```, you can use it instead of
+providing a complete set of address data.
+
+{% highlight json %}
+{% include shipment_quotes_post_request_with_address_id.json %}
+{% endhighlight %}
+
+You can also omit the ```from``` parameter if the users has configured a standard ship from address
+in her/his shipcloud profile.
+
 <i class="glyphicon glyphicon-arrow-right"></i> JSON schema: [Shipment Quotes request]({{ site.baseurl }}/reference/shipment_quotes_request_schema.html)
 
 #### Response


### PR DESCRIPTION
When creating a ShipmentQuote, one can define addresses by either supplying a full set of data or the id of an previously added address. You can also omit the from address completely if the user has defined a standard ship from address.