### PR TITLE
added reference and examples for shipments with pickup requests

### DIFF
--- a/_includes/reference/shipment_quotes_request_parameters.md
+++ b/_includes/reference/shipment_quotes_request_parameters.md
@@ -1,6 +1,6 @@
 __Parameters:__
 
-- __carrier__* (string), the carrier you want to use. Possible values are "dpd", "dhl", "gls", "hermes", "iloxx", "ups", "fedex"
+- __carrier__* (string), the carrier you want to use. Possible values are "dpd", "dhl", "gls", "hermes", "iloxx", "ups", "tnt", "fedex" and "liefery"
 - __service__ (string), service that should be used. Available values are "returns", "standard", "one_day" , "one_day_early", "same_day". See [supported services]({{ site.baseurl }}/concepts/#supported-services) for detailed information
 - __to__* (object), describes the receivers address. See [address request]({{ site.baseurl }}/reference/#addresses) for a detailed definition.
 - __from__ (object, optional), describes the senders address. See [address request]({{ site.baseurl }}/reference/#addresses) for a detailed definition.

--- a/_includes/reference/shipments_request_parameters.md
+++ b/_includes/reference/shipments_request_parameters.md
@@ -1,6 +1,6 @@
 __Parameters:__
 
-- __carrier__* (string), the carrier you want to use. Possible values are "dpd", "dhl", "gls", "hermes", "iloxx", "ups", "fedex"
+- __carrier__* (string), the carrier you want to use. Possible values are "dpd", "dhl", "gls", "hermes", "iloxx", "ups", "tnt", "fedex" and "liefery"
 - __to__* (object), describes the receivers address. See [address request]({{ site.baseurl }}/reference/#addresses) for a detailed definition.
 - __from__* (object), describes the senders address. If missing, the default sender address (if defined in your shipcloud account) will be used. See [address request]({{ site.baseurl }}/reference/#addresses) for a detailed definition.
 - __package__*, object describing the package dimensions
@@ -15,6 +15,11 @@ __Parameters:__
   - __type__ (string, optional), carrier specific package type declaration. Available values are "books", "bulk", "letter", "parcel" and "parcel_letter". See [package types]({{ site.baseurl }}/concepts/#package-types) for detailed information.
 - __service__ (string, optional), service that should be used. Available values are "returns", "standard", "one_day" , "one_day_early". See [supported services]({{ site.baseurl }}/concepts/#supported-services) for detailed information.
 - __additional_services__ (array, optional), array of objects where you can define additional services to be used. See [additional services]({{ site.baseurl }}/recipes/#additional-services) for detailed information
+- __pickup__ (object, optional), describes the pickup request. Mandatory for creating shipments with TNT as carrier - see [TNT specifics]({{ site.baseurl }}/concepts/#shipments-with-pickup-requests)
+  - __pickup_time__ (object), contains the earliest and latest pickup time in iso8601
+    - __earliest__ (datetime), timestamp describing the earliest time the carrier should pickup the shipment
+    - __latest__ (datetime), timestamp describing the latest time the carrier should pickup the shipment
+  - __pickup_address__ (object, optional), describes the pickup address. See [address request]({{ site.baseurl }}/reference/#addresses) for a detailed definition.
 - __reference_number__ (string, optional), a reference number (max. 30 characters) that you want this shipment to be identified with. You can use this afterwards to easier find the shipment in the shipcloud.io backoffice
 - __description__ (string), mandatory if you're using UPS and the following conditions are true: from and to countries are not the same; from and/or to countries are not in the EU; from and to countries are in the EU and the shipments service is not standard
 - __label__ (object, optional), define the DIN size the returned label should have. See [label size recipe]({{ site.baseurl }}/recipes/#label-size) for detailed information

--- a/_includes/schemas/shipment_quotes_request.json
+++ b/_includes/schemas/shipment_quotes_request.json
@@ -4,7 +4,7 @@
   "properties": {
     "carrier": {
       "type": "string",
-      "enum": ["dhl", "dpag", "ups", "dpd", "hermes", "gls", "fedex", "liefery"],
+      "enum": ["dhl", "dpag", "ups", "dpd", "hermes", "gls", "tnt", "fedex", "liefery"],
       "description": "acronym of the carrier you want to use"
     },
     "service": {

--- a/_includes/schemas/shipments_request.json
+++ b/_includes/schemas/shipments_request.json
@@ -4,7 +4,7 @@
   "properties": {
     "carrier": {
       "type": "string",
-      "enum": ["dhl", "dpag", "ups", "dpd", "hermes", "gls", "fedex", "liefery"],
+      "enum": ["dhl", "dpag", "ups", "dpd", "hermes", "gls", "tnt", "fedex", "liefery"],
       "description": "acronym of the carrier you want to use"
     },
     "to": {
@@ -71,6 +71,10 @@
       },
       "required": ["name"],
       "additionalProperties": false
+    },
+    "pickup": {
+      "$ref": "#/definitions/pickup",
+      "description": "pickup request for this shipment"
     },
     "create_shipping_label": {
       "type": "boolean",
@@ -150,6 +154,33 @@
       "required": ["width", "height", "length", "weight"],
       "additionalProperties": false,
       "description": "defines package dimensions"
+    },
+    "pickup": {
+      "type": "object",
+      "properties": {
+        "pickup_time": {
+          "type": "object",
+          "properties": {
+            "earliest": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "latest": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          "description": "defined time window when the carrier should pickup shipments",
+          "required": ["earliest", "latest"],
+          "additionalProperties": false
+        },
+        "pickup_address": {
+          "$ref": "#/definitions/address",
+          "description": "address where the shipment should be picked up"
+        }
+      },
+      "required": ["pickup_time"],
+      "additionalProperties": false
     }
   }
 }

--- a/_includes/shipments_post_request_with_pickup.json
+++ b/_includes/shipments_post_request_with_pickup.json
@@ -1,0 +1,37 @@
+{
+  "to": {
+      "company": "Receiver Inc.",
+      "first_name": "Max",
+      "last_name": "Mustermann",
+      "street": "Beispielstrasse",
+      "street_no": "42",
+      "city": "Hamburg",
+      "zip_code": "22100",
+      "country": "DE"
+  },
+  "package": {
+      "weight": 1.5,
+      "length": 20,
+      "width": 20,
+      "height": 20
+  },
+  "pickup": {
+    "pickup_time": {
+      "earliest": "2015-09-15T09:00:00+02:00",
+      "latest": "2015-09-15T18:00:00+02:00"
+    },
+    "pickup_address": {
+      "company": "Sender Ltd.",
+      "first_name": "Jane",
+      "last_name": "Doe",
+      "street": "Musterstraße",
+      "street_no": "42",
+      "zip_code": "54321",
+      "city": "Musterstadt",
+      "country": "DE"
+     }
+  },
+  "carrier": "tnt",
+  "service": "one_day",
+  "create_shipping_label": true
+}

--- a/concepts/index.md
+++ b/concepts/index.md
@@ -190,6 +190,26 @@ ___package.description___ is mandatory
 by the carrier, which is why this parameter won't be included in the response when creating a
 shipment.
 
+### TNT
+
+#### Shipments with Pickup Requests
+If you don't have regular pickups by TNT you will have to request pickups by the carrier. In
+contrast to other carriers we support, pickup requests for TNT have to be done a little
+differently. When creating a shipment for TNT a pickup request has to be made at the same time.
+Therefore you can add a pickup element when creating your shipment request.
+
+The following rules apply for pickups:
+
+* the date for `pickup_time.earliest` and `pickup_time.latest` has to be same
+* supplying a `pickup_address` is optional
+
+<kbd>POST</kbd> __/v1/shipments__
+
+{% highlight json %}
+{% include shipments_post_request_with_pickup.json %}
+{% endhighlight %}
+
+
 ### UPS
 * when using the service ___returns___ the parameter ___package.description___ is mandatory
 * if one of the following conditions is true, the parameter ___description___ is mandatory:


### PR DESCRIPTION
- Some carriers require a pickup request to be send with the creation of
the shipping label. Therefore you can now send a pickup object with your
shipment request.
- We're also now supporting TNT as a new carrier