### PR TITLE
remove shipment status "shipcloud_label_created" from eventy types

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -12,6 +12,13 @@ work with any other release modifiers than major versions.
 
 **Notice**: Not everything we do affects the viewable parts of our api.
 
+
+## [20161019] - 2016-10-19
+
+### Removed
+- We've removed the event type `shipcloud_label_created` because it was too confusing and users
+didn't get the difference between this one and `label_created`.
+
 ## [20160511] - 2016-05-11
 
 ### Added

--- a/_includes/concepts/webhooks_legend.html
+++ b/_includes/concepts/webhooks_legend.html
@@ -9,10 +9,6 @@
       </thead>
       <tbody>
         <tr>
-          <td><span class="label label-info">shipment.tracking.shipcloud_label_created</span></td>
-          <td>shipment created at shipcloud</td>
-        </tr>
-        <tr>
           <td><span class="label label-info">shipment.tracking.label_created</span></td>
           <td>A label has been created</td>
         </tr>

--- a/_includes/schemas/shipments_response.json
+++ b/_includes/schemas/shipments_response.json
@@ -63,7 +63,7 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": ["shipcloud_label_created", "label_created", "picked_up", "delivered", "not_delivered", "transit", "exception", "out_for_delivery", "destroyed", "unknown", "canceled"],
+                  "enum": ["label_created", "picked_up", "delivered", "not_delivered", "transit", "exception", "out_for_delivery", "destroyed", "unknown", "canceled"],
                   "description": "key describing the status"
                 },
                 "details": {

--- a/_includes/shipments_index_response.json
+++ b/_includes/shipments_index_response.json
@@ -41,7 +41,7 @@
       "tracking_events": [{
         "timestamp": "2014-11-12T14:03:45+01:00",
         "location": "shipcloud",
-        "status": "shipcloud_label_created",
+        "status": "label_created",
         "details": "Es wurde eine Sendung angelegt"
       }]
     }]
@@ -87,7 +87,7 @@
       "tracking_events": [{
         "timestamp": "2014-11-12T14:03:45+01:00",
         "location": "shipcloud",
-        "status": "shipcloud_label_created",
+        "status": "label_created",
         "details": "Es wurde eine Sendung angelegt"
       }]
     }]


### PR DESCRIPTION
since we no longer use it