### PR TITLE
add DHL Express as a standalone carrier

### DIFF
--- a/_includes/schemas/shipments_request.json
+++ b/_includes/schemas/shipments_request.json
@@ -112,7 +112,7 @@
         "country": { "type": "string", "description": "Country as uppercase ISO 3166-1 alpha-2 code" },
         "phone": {
           "type": "string",
-          "description": "telephone number (mandatory when using UPS and the following terms apply: service is one_day or one_day_early or ship to country is different than ship from country)"
+          "description": "telephone number (mandatory when the following terms apply - when carrier is UPS: service is one_day or one_day_early or ship to country is different than ship from country. Carrier is DHL Express: always provide phone number.)"
         }
       },
       "required": ["last_name", "street", "street_no", "city", "zip_code", "country"],

--- a/_includes/shipments_post_request_with_pickup_by_dhl_express.json
+++ b/_includes/shipments_post_request_with_pickup_by_dhl_express.json
@@ -1,0 +1,40 @@
+{
+  "to": {
+      "company": "Receiver Inc.",
+      "first_name": "Max",
+      "last_name": "Mustermann",
+      "street": "Beispielstrasse",
+      "street_no": "42",
+      "city": "Hamburg",
+      "state": "HH",
+      "zip_code": "22100",
+      "country": "DE",
+      "phone": "555-12345"
+  },
+  "package": {
+      "weight": 1.5,
+      "length": 20,
+      "width": 20,
+      "height": 20
+  },
+  "pickup": {
+    "pickup_time": {
+      "earliest": "2015-09-15T09:00:00+02:00",
+      "latest": "2015-09-15T18:00:00+02:00"
+    },
+    "pickup_address": {
+      "company": "Sender Ltd.",
+      "first_name": "Jane",
+      "last_name": "Doe",
+      "street": "Musterstraße",
+      "street_no": "42",
+      "zip_code": "54321",
+      "city": "Musterstadt",
+      "country": "DE"
+     }
+  },
+  "description": "Important goods that need to be delivered fast!",
+  "carrier": "dhl_express",
+  "service": "one_day",
+  "create_shipping_label": true
+}

--- a/concepts/index.md
+++ b/concepts/index.md
@@ -189,6 +189,26 @@ day.
 * when using the service ___one_day___ or ___one_day_early___ the parameter
 ___package.description___ is mandatory
 
+### DHL Express
+
+#### Shipments with Pickup Requests
+If you don't have regular pickups by DHL Express you will have to request a pickup when creating a
+shipment. Therefore, you can add a pickup element to your shipment request.
+
+The following rules apply for pickups by DHL Express:
+
+* the date for `pickup_time.earliest` and `pickup_time.latest` has to be the same
+* supplying a `pickup_address` is optional
+* supplying a `description` is mandatory
+* supplying `phone` is mandatory for sender and recipient addresses
+* `state` has to be 2 characters long
+
+<kbd>POST</kbd> __/v1/shipments__
+
+{% highlight json %}
+{% include shipments_post_request_with_pickup_by_dhl_express.json %}
+{% endhighlight %}
+
 ### GLS
 * shipments will receive a carrier tracking number (```carrier_tracking_no```) with the first scan
 by the carrier, which is why this parameter won't be included in the response when creating a
@@ -207,7 +227,7 @@ contrast to other carriers we support, pickup requests for TNT have to be done a
 differently. When creating a shipment for TNT a pickup request has to be made at the same time.
 Therefore you can add a pickup element when creating your shipment request.
 
-The following rules apply for pickups:
+The following rules apply for pickups by TNT:
 
 * the date for `pickup_time.earliest` and `pickup_time.latest` has to be same
 * supplying a `pickup_address` is optional


### PR DESCRIPTION
We've changed the way, DHL Express is integrated into our platform - since DHL Express in itself is a different service than DHL. This also makes it possible for customers to have a mix and match of DHL and DHL Express contracts within their account. 
