### PR TITLE
added tracker ressource

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -12,6 +12,12 @@ work with any other release modifiers than major versions.
 
 **Notice**: Not everything we do affects the viewable parts of our api.
 
+## [20170127] - 2017-01-27
+
+### Added
+- Introducing the [trackers ressource]({{ site.baseurl }}/reference/#trackers) to be able to import
+  shipments by sending us carrier tracking numbers of shipments that were created, using another
+  software.
 
 ## [20170119] - 2017-01-19
 

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,11 @@ twitter_username: shipcloud_devs
 github_username:  shipcloud
 integration_guide_url: >
   https://www.dropbox.com/s/0c2mguqlvwdwclg/shipcloud_integration_guide_v_0_7.pdf?dl=0
+shipcloud:
+  supported_carriers:
+    as_display_names: 'DHL, Deutsche Post, UPS, DPD, Hermes, GLS, MyDPD Business (iloxx), TNT, FedEx, Liefery and GO!'
+    as_keys: '"dhl", "dpag", "ups", "dpd", "hermes", "gls", "iloxx", "tnt", "fedex", "liefery" and "go"'
+    as_keys_array: '"dhl", "dpag", "ups", "dpd", "hermes", "gls", "iloxx", "tnt", "fedex", "liefery", "go"'
 
 # Build settings
 markdown: kramdown

--- a/_includes/navs/reference_nav.html
+++ b/_includes/navs/reference_nav.html
@@ -57,5 +57,13 @@
         <li><a href="#deleting-a-webhook">Delete</a></li>
       </ul>
     </li>
+    <li>
+      <a href="#trackers">Trackers</a>
+      <ul class="nav">
+        <li><a href="#creating-a-tracker">Create</a></li>
+        <li><a href="#getting-a-list-of-trackers">Index</a></li>
+        <li><a href="#show-a-tracker">Read</a></li>
+      </ul>
+    </li>
   </ul>
 </div>

--- a/_includes/reference/trackers_request_parameters.md
+++ b/_includes/reference/trackers_request_parameters.md
@@ -1,0 +1,6 @@
+__Parameters:__
+
+- __carrier_tracking_no__ (string), the tracking number provided by the carrier
+- __carrier__ (array), name of the carrier you want to use. Possible values are {{ site.shipcloud.supported_carriers.as_keys }}
+- __to__* (object, optional), describes the receivers address. See [address request]({{ site.baseurl }}/reference/#addresses) for a detailed definition.
+- __from__* (object, optional), describes the senders address. If missing, the default sender address (if defined in your shipcloud account) will be used. See [address request]({{ site.baseurl }}/reference/#addresses) for a detailed definition.

--- a/_includes/reference/trackers_request_togglebox.html
+++ b/_includes/reference/trackers_request_togglebox.html
@@ -1,0 +1,17 @@
+<div class="panel-group" id="trackers_request_togglebox">
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h4 class="panel-title">
+        <a data-toggle="collapse" data-parent="#trackers_request_togglebox" href="#trackers_request_togglebox_collapsable">
+          <i class="glyphicon glyphicon-chevron-down"></i> Parameter description (POST/PUT)
+        </a>
+      </h4>
+    </div>
+    <div id="trackers_request_togglebox_collapsable" class="panel-collapse collapse">
+      <div class="panel-body">
+        {% capture trackers_request_parameters %}{% include reference/trackers_request_parameters.md %}{% endcapture %}
+        {{ trackers_request_parameters | markdownify }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/_includes/schemas/trackers_request.json
+++ b/_includes/schemas/trackers_request.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Tracker",
+  "description": "Trackers allow you to monitor a shipment even though it wasn't created using shipcloud",
+  "type": "object",
+  "properties": {
+    "carrier_tracking_no": {
+      "type": "string",
+      "description": "Tracking number (provided by the carrier) of the shipment which should be monitored"
+    },
+    "carrier": {
+      "type": "string",
+      "enum": [{{ site.shipcloud.supported_carriers.as_keys_array }}],
+      "description": "acronym of the carrier the shipment was created with"
+    },
+    "to": {
+      "$ref": "#/definitions/address",
+      "description": "the receivers address"
+    },
+    "from": {
+      "$ref": "#/definitions/address",
+      "description": "the senders address"
+    }
+  },
+  "required": ["carrier_tracking_no", "carrier"],
+  "additionalProperties": false,
+  "definitions": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "identifier of a previously created address"
+        },
+        "company": { "type": "string" },
+        "first_name": { "type": "string" },
+        "last_name": { "type": "string" },
+        "care_of": { "type": "string" },
+        "street": { "type": "string" },
+        "street_no": { "type": "string" },
+        "city": { "type": "string" },
+        "zip_code": { "type": "string" },
+        "state": { "type": "string" },
+        "country": { "type": "string", "description": "Country as uppercase ISO 3166-1 alpha-2 code" },
+        "phone": {
+          "type": "string",
+          "description": "telephone number"
+        }
+      },
+      "required": ["last_name", "street", "street_no", "city", "zip_code", "country"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/_includes/schemas/trackers_response.json
+++ b/_includes/schemas/trackers_response.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "the tracker id that can be used for requesting info about a tracker"
+    },
+    "tracking_code": {
+      "type": "string",
+      "description": "deprecated: will be renamed in `carrier_tracking_no`. tracking number (provided by the carrier) for this shipment"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["registered", "label_created", "picked_up", "delivered", "not_delivered", "transit", "exception", "out_for_delivery", "destroyed", "unknown", "canceled"],
+      "description": "key describing the current status"
+    },
+    "created_at": {
+      "type": "date-time",
+      "description": "timestamp the tracker was created"
+    },
+    "from": {
+      "$ref": "#/definitions/address",
+      "description": "the senders address"
+    },
+    "tracking_status_updated_at": {
+      "type": "date-time",
+      "description": "timestamp the tracking status was last updated"
+    },
+    "last_polling_at": {
+      "type": "date-time",
+      "description": "timestamp the shipment status was last polled at the carrier"
+    },
+    "next_polling_at": {
+      "type": "date-time",
+      "description": "timestamp the shipment status will be polled the next time"
+    },
+    "shipment_id": {
+      "type": "string",
+      "description": "id of the corresponding shipment within shipcloud"
+    },
+    "carrier": {
+      "type": "string",
+      "enum": [{{ site.shipcloud.supported_carriers.as_keys_array }}],
+      "description": "acronym of the carrier the shipment was sent with"
+    },
+    "to": {
+      "$ref": "#/definitions/address",
+      "description": "the receivers address"
+    },
+    "tracking_events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "timestamp": {
+            "type": "date-time",
+            "description": "timestamp of when this event occured"
+          },
+          "location": {
+            "type": "string",
+            "description": "location of the package at this moment"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["registered", "label_created", "picked_up", "delivered", "not_delivered", "transit", "exception", "out_for_delivery", "destroyed", "unknown", "canceled"],
+            "description": "key describing the status"
+          },
+          "details": {
+            "type": "string",
+            "description": "message the carrier sends to describe the shipments status"
+          }
+        },
+        "required": ["timestamp", "location", "status", "details"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["id", "tracking_code", "status", "created_at", "tracking_status_updated_at", "last_polling_at", "next_polling_at", "shipment_id", "carrier"],
+  "additionalProperties": false,
+  "definitions": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "identifier of a previously created address"
+        },
+        "company": { "type": "string" },
+        "first_name": { "type": "string" },
+        "last_name": { "type": "string" },
+        "care_of": { "type": "string" },
+        "street": { "type": "string" },
+        "street_no": { "type": "string" },
+        "city": { "type": "string" },
+        "zip_code": { "type": "string" },
+        "state": { "type": "string" },
+        "country": { "type": "string", "description": "Country as uppercase ISO 3166-1 alpha-2 code" },
+        "phone": {
+          "type": "string",
+          "description": "telephone number"
+        }
+      },
+      "required": ["last_name", "street", "street_no", "city", "zip_code", "country"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/_includes/trackers_get_response.json
+++ b/_includes/trackers_get_response.json
@@ -1,0 +1,51 @@
+{
+  "id": "4a6922e2-09ad-4724-807c-7b4e572d3c6b",
+  "tracking_code": "723558934169",
+  "status": "delivered",
+  "created_at": "2015-07-20T09:35:23+02:00",
+  "to": {
+    "company": null,
+    "first_name": "Hans",
+    "last_name": "Meier",
+    "care_of": null,
+    "street": "Semmelweg",
+    "street_no": "1",
+    "zip_code": "12345",
+    "city": "Hamburg",
+    "state": null,
+    "country": "DE"
+  },
+  "from": {
+    "company": "webionate GmbH",
+    "first_name": null,
+    "last_name": "Fahlbusch",
+    "care_of": null,
+    "street": "Lüdmoor",
+    "street_no": "35a",
+    "zip_code": "22175",
+    "city": "Hamburg",
+    "state": null,
+    "country": "DE"
+  },
+  "tracking_status_updated_at": "2015-08-01T11:35:23+02:00",
+  "last_polling_at": "2015-08-03T10:23:45+02:00",
+  "next_polling_at": null,
+  "shipment_id": "6306d78506af51913c89b0af45b1ba7d430e4208",
+  "carrier": "ups",
+  "tracking_events": [
+    {
+      "id": "0aa3479-8695-4a6a-8326-ed55df65b9a6",
+      "timestamp": "2015-07-21T08:57:44+02:00",
+      "location": "Hamburg",
+      "status": "out_for_delivery",
+      "details": "Some details"
+    },
+    {
+      "id": "0aa3479-8695-4a6a-8326-ed55df65b9a6",
+      "timestamp": "2015-07-21T10:57:44+02:00",
+      "location": "Hamburg",
+      "status": "delivered",
+      "details": "Some more details"
+    }
+  ]
+}

--- a/_includes/trackers_index_response.json
+++ b/_includes/trackers_index_response.json
@@ -1,0 +1,101 @@
+{
+  "trackers" : [
+    {
+      "id": "4a6922e2-09ad-4724-807c-7b4e572d3c6b",
+      "tracking_code": "723558934169",
+      "to": {
+        "company": null,
+        "first_name": "Hans",
+        "last_name": "Meier",
+        "care_of": null,
+        "street": "Semmelweg",
+        "street_no": "1",
+        "zip_code": "12345",
+        "city": "Hamburg",
+        "state": null,
+        "country": "DE"
+      },
+      "status": "delivered",
+      "created_at": "2015-07-20T09:35:23+02:00",
+      "tracking_status_updated_at": "2015-08-01T11:35:23+02:00",
+      "last_polling_at": "2015-08-03T10:23:45+02:00",
+      "next_polling_at": "2015-08-03T12:23:45+02:00",
+      "shipment_id": "6306d78506af51913c89b0af45b1ba7d430e4208",
+      "carrier": "ups",
+      "tracking_events": [
+        {
+          "id": "0aa3479-8695-4a6a-8326-ed55df65b9a6",
+          "timestamp": "2015-07-21T08:57:44+02:00",
+          "location": "Hamburg",
+          "status": "out_for_delivery",
+          "details": "Some details"
+        },
+        {
+          "id": "0aa3479-8695-4a6a-8326-ed55df65b9a6",
+          "timestamp": "2015-07-21T10:57:44+02:00",
+          "location": "Hamburg",
+          "status": "delivered",
+          "details": "Some more details"
+        }
+      ]
+    },
+    {
+      "id": "5452ec46-560e-42ba-adf7-8a1b46d60ece",
+      "tracking_code": "JJD000390006125214950",
+      "to": {
+        "company": null,
+        "first_name": "Hans",
+        "last_name": "Meier",
+        "care_of": null,
+        "street": "Semmelweg",
+        "street_no": "1",
+        "zip_code": "12345",
+        "city": "Hamburg",
+        "state": null,
+        "country": "DE"
+      },
+      "from": {
+        "company": "webionate GmbH",
+        "first_name": null,
+        "last_name": "Fahlbusch",
+        "care_of": null,
+        "street": "Lüdmoor",
+        "street_no": "35a",
+        "zip_code": "22175",
+        "city": "Hamburg",
+        "state": null,
+        "country": "DE"
+      },
+      "status": "delivered",
+      "created_at": "2016-12-26T08:48:21+02:00",
+      "tracking_status_updated_at": "2016-12-28T12:16:44+02:00",
+      "last_polling_at": "2016-12-28T22:10:45+02:00",
+      "next_polling_at": "2016-12-28T22:12:45+02:00",
+      "shipment_id": "cbceeb51314c88e8047b8b5dfd92313528238b88",
+      "carrier": "dhl",
+      "tracking_events": [
+        {
+          "id": "0aa3479-8695-4a6a-8326-ed55df65b9a6",
+          "timestamp": "2016-12-26T08:48:21+02:00",
+          "location": "Radefeld",
+          "status": "transit",
+          "details": "Lieferung hat das Logistikzentrum verlassen und ist unterwegs."
+        },
+        {
+          "id": "0aa3479-8695-4a6a-8326-ed55df65b9a6",
+          "timestamp": "2016-12-28T09:34:11+02:00",
+          "location": "Hamburg",
+          "status": "out_for_delivery",
+          "details": "Sendung wird zugestellt."
+        },
+        {
+          "id": "0aa3479-8695-4a6a-8326-ed55df65b9a6",
+          "timestamp": "2016-12-28T12:16:44+02:00",
+          "location": "Hamburg",
+          "status": "delivered",
+          "details": "Ihre Sendung wurde zugestellt. Die Sendung wurde zugestellt an Simon Fröhler shipcloud GmbH. "
+        }
+      ]
+    }
+  ]
+}

--- a/_includes/trackers_post_put_request.json
+++ b/_includes/trackers_post_put_request.json
@@ -1,0 +1,4 @@
+{
+  "carrier_tracking_no": "723558934169",
+  "carrier": "UPS"
+}

--- a/_includes/trackers_post_put_response.json
+++ b/_includes/trackers_post_put_response.json
@@ -1,0 +1,24 @@
+{
+  "id": "4a6922e2-09ad-4724-807c-7b4e572d3c6b",
+  "tracking_code": "723558934169",
+  "status": "registered",
+  "created_at": "2015-07-20T09:35:23+02:00",
+  "to": {
+    "company": null,
+    "first_name": "Hans",
+    "last_name": "Meier",
+    "care_of": null,
+    "street": "Semmelweg",
+    "street_no": "1",
+    "zip_code": "12345",
+    "city": "Hamburg",
+    "state": null,
+    "country": "DE"
+  },
+  "tracking_status_updated_at": null,
+  "last_polling_at": null,
+  "next_polling_at": "2015-07-20T09:35:23+02:00",
+  "shipment_id": "12345abcdef",
+  "carrier": "ups",
+  "tracking_events": []
+}

--- a/reference/index.md
+++ b/reference/index.md
@@ -486,3 +486,60 @@ __URL parameters:__
 {% highlight json %}
 {}
 {% endhighlight %}
+
+## Trackers
+Trackers make it possible to track a shipment that wasn't creating using shipcloud. They are
+basically a way to monitor shipments created elsewhere. All you have to do is provide us with the
+tracking number you received from the carrier as well as its corresponding name acronym.
+
+{% include reference/trackers_request_togglebox.html %}
+
+### Creating a tracker
+
+This is the way to create a tracker based on a tracking number provided by one of our supported
+carriers ({{ site.shipcloud.supported_carriers.as_display_names }})
+
+#### Request
+<kbd>POST</kbd> __/v1/trackers__
+
+{% highlight json %}
+{% include trackers_post_put_request.json %}
+{% endhighlight %}
+
+<i class="glyphicon glyphicon-arrow-right"></i> JSON schema: [Create tracker request]({{ site.baseurl }}/reference/trackers_request_schema.html)
+
+#### Response
+{% include headers/200_ok.html %}
+{% highlight json %}
+{% include trackers_post_put_response.json %}
+{% endhighlight %}
+
+<i class="glyphicon glyphicon-arrow-right"></i> JSON schema: [Create tracker response]({{ site.baseurl }}/reference/trackers_response_schema.html)
+
+### Getting a list of trackers
+
+#### Request
+<kbd>GET</kbd> __/v1/trackers__
+
+#### Response
+{% include headers/200_ok.html %}
+{% highlight json %}
+{% include trackers_index_response.json %}
+{% endhighlight %}
+
+### Show a tracker
+
+#### Request
+<kbd>GET</kbd> __/v1/trackers/:id__
+
+__GET parameters:__
+
+- __id__, the id attribute that was returned when creating the tracker
+
+#### Response
+{% include headers/200_ok.html %}
+{% highlight json %}
+{% include trackers_get_response.json %}
+{% endhighlight %}
+
+<i class="glyphicon glyphicon-arrow-right"></i> JSON schema: [Tracker response]({{ site.baseurl }}/reference/trackers_response_schema.html)

--- a/reference/trackers_request_schema.md
+++ b/reference/trackers_request_schema.md
@@ -1,0 +1,9 @@
+---
+title: shipcloud create tracker request JSON schema
+---
+
+{% highlight json %}
+{% include schemas/trackers_request.json %}
+{% endhighlight %}
+
+<i class="glyphicon glyphicon-download-alt"></i> [download]({{ site.baseurl }}/schemas/trackers_request.json)

--- a/reference/trackers_response_schema.md
+++ b/reference/trackers_response_schema.md
@@ -1,0 +1,9 @@
+---
+title: shipcloud trackers response JSON schema
+---
+
+{% highlight json %}
+{% include schemas/trackers_response.json %}
+{% endhighlight %}
+
+[<i class="glyphicon glyphicon-download-alt"></i> download]({{ site.baseurl }}/schemas/trackers_response.json)

--- a/schemas/trackers_request.json
+++ b/schemas/trackers_request.json
@@ -1,0 +1,4 @@
+---
+layout: none
+---
+{% include schemas/trackers_request.json %}

--- a/schemas/trackers_response.json
+++ b/schemas/trackers_response.json
@@ -1,0 +1,4 @@
+---
+layout: none
+---
+{% include schemas/trackers_response.json %}


### PR DESCRIPTION
Trackers make it possible to track a shipment that wasn't creating using shipcloud. They are basically a way to monitor shipments created elsewhere. All you have to do is provide us with the tracking number you received from the carrier as well as its corresponding name acronym.