### PR TITLE
display shipper_notification_email when reading shipments

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -13,6 +13,12 @@ work with any other release modifiers than major versions.
 **Notice**: Not everything we do affects the viewable parts of our api.
 
 
+## [20170119] - 2017-01-19
+
+### Added
+- When [reading a shipment]({{ site.baseurl }}/reference/#getting-information-about-a-shipment),
+  `shipper_notification_email` will now be returned (_if specified during creation_)
+
 ## [20161021] - 2016-10-21
 
 ### Added

--- a/_includes/schemas/shipments_response.json
+++ b/_includes/schemas/shipments_response.json
@@ -2,38 +2,34 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
-    "id": {
+    "carrier": {
       "type": "string",
-      "description": "the shipment id that can be used for requesting info about a shipment or tracking it"
+      "enum": ["dhl", "dpag", "ups", "dpd", "hermes", "iloxx", "gls", "tnt", "fedex", "liefery"],
+      "description": "acronym of the carrier"
     },
     "carrier_tracking_no": {
       "type": "string",
       "description": "the original tracking number that can be used on the carriers website"
     },
-    "carrier": {
-      "type": "string",
-      "enum": ["dhl", "ups", "dpd", "hermes", "gls"],
-      "description": "acronym of the carrier"
-    },
     "created_at": {
       "type": "date-time",
       "description": "timestamp the shipment was created"
-    },
-    "tracking_url": {
-      "type": "string",
-      "description": "URL you can send your customers so they can track this shipment"
-    },
-    "label_url": {
-      "type": "string",
-      "description": "URL where you can download the label in pdf format"
     },
     "from": {
       "$ref": "#/definitions/address",
       "description": "If missing, the default sender address (if defined in your shipcloud account) will be used"
     },
-    "to": {
-      "$ref": "#/definitions/address",
-      "description": "the receivers address"
+    "id": {
+      "type": "string",
+      "description": "the shipment id that can be used for requesting info about a shipment or tracking it"
+    },
+    "label_url": {
+      "type": "string",
+      "description": "URL where you can download the label in pdf format"
+    },
+    "notification_email": {
+      "type": "string",
+      "description": "email address of the receiver who should be notified of a change of shipment status by shipcloud"
     },
     "packages": {
       "type": "array",
@@ -87,23 +83,40 @@
     "reference_number": {
       "type": "string",
       "description": "a reference number (max. 30 characters) that you want this shipment to be identified with. You can use this afterwards to easier find the shipment in the shipcloud.io backoffice"
+    },
+    "service": {
+      "type": "string",
+      "description": "the service that was used for creating this shipment"
+    },
+    "shipper_notification_email": {
+      "type": "string",
+      "description": "email address of the shipper who should be notified of a change of shipment status by shipcloud"
+    },
+    "to": {
+      "$ref": "#/definitions/address",
+      "description": "the receivers address"
+    },
+    "tracking_url": {
+      "type": "string",
+      "description": "URL you can send your customers so they can track this shipment"
     }
   },
-  "required": ["id", "carrier_tracking_no", "carrier", "created_at", "tracking_url", "label_url", "from", "to", "packages", "price", "reference_number"],
+  "required": ["id", "carrier_tracking_no", "carrier", "created_at", "tracking_url", "label_url", "from", "to", "packages", "price", "reference_number", "service"],
   "additionalProperties": false,
   "definitions": {
     "address": {
       "type": "object",
       "properties": {
+        "care_of": { "type": "string" },
+        "city": { "type": "string" },
         "company": { "type": "string" },
+        "country": { "type": "string", "description": "Country as uppercase ISO 3166-1 alpha-2 code" },
         "first_name": { "type": "string" },
         "last_name": { "type": "string" },
-        "care_of": { "type": "string" },
+        "state": { "type": "string" },
         "street": { "type": "string" },
         "street_no": { "type": "string" },
-        "city": { "type": "string" },
         "zip_code": { "type": "string" },
-        "country": { "type": "string", "description": "Country as uppercase ISO 3166-1 alpha-2 code" },
         "phone": {
           "type": "string",
           "description": "telephone number (mandatory when using UPS and the following terms apply: service is one_day or one_day_early or ship to country is different than ship from country)"
@@ -115,10 +128,10 @@
     "package": {
       "type": "object",
       "properties": {
-        "width":  { "type": "number" },
         "height": { "type": "number" },
         "length": { "type": "number" },
-        "weight": { "type": "number" }
+        "weight": { "type": "number" },
+        "width":  { "type": "number" }
       },
       "required": ["width", "height", "length", "weight"],
       "additionalProperties": false,

--- a/_includes/shipments_get_response.json
+++ b/_includes/shipments_get_response.json
@@ -1,10 +1,7 @@
 {
-  "id": "3a186c51d4281acbecf5ed38805b1db92a9d668b",
-  "carrier_tracking_no": "84168117830018",
   "carrier": "dhl",
+  "carrier_tracking_no": "84168117830018",
   "created_at": "2013-04-16T10:43:04Z",
-  "tracking_url": "http://track.shipcloud.io/3a186c51d4",
-  "label_url": "http://api.shipcloud.io/shipping_label_3a186c51d4.pdf",
   "from": {
     "company": "Musterfirma",
     "first_name": "Hans",
@@ -17,17 +14,9 @@
     "state": null,
     "country": "DE"
   },
-  "to": {
-    "company": "Receiver Inc.",
-    "first_name": "Max",
-    "last_name": "Mustermann",
-    "street": "Beispielstrasse",
-    "street_no": "42",
-    "city": "Hamburg",
-    "zip_code": "22100",
-    "state": null,
-    "country": "DE"
-  },
+  "id": "3a186c51d4281acbecf5ed38805b1db92a9d668b",
+  "label_url": "http://api.shipcloud.io/shipping_label_3a186c51d4.pdf",
+  "notification_email": "receiver@notification.com",
   "packages": [
     {
       "id": "3af8f7e5af196e1950deebd389a87406e1e5bb80",
@@ -58,5 +47,19 @@
     }
   ],
   "price": 3.4,
-  "reference_number": "ref123456"
+  "reference_number": "ref123456",
+  "service": "standard",
+  "shipper_notification_email": "shipper@notification.com",
+  "to": {
+    "company": "Receiver Inc.",
+    "first_name": "Max",
+    "last_name": "Mustermann",
+    "street": "Beispielstrasse",
+    "street_no": "42",
+    "city": "Hamburg",
+    "zip_code": "22100",
+    "state": null,
+    "country": "DE"
+  },
+  "tracking_url": "http://track.shipcloud.io/3a186c51d4"
 }


### PR DESCRIPTION
when reading a shipment, `shipper_notification_email` will now be returned (if specified during creation)