### PR TITLE
replaced `tracking_code` with `carrier_tracking_no`

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -12,6 +12,12 @@ work with any other release modifiers than major versions.
 
 **Notice**: Not everything we do affects the viewable parts of our api.
 
+## [20170202] - 2017-02-02
+
+### Changed
+- As previously stated, we've replaced the deprecated parameter `tracking_code` with
+  `carrier_tracking_no`. Tracker objects are using this parameter from now on.
+
 ## [20170127] - 2017-01-27
 
 ### Added

--- a/_includes/schemas/trackers_response.json
+++ b/_includes/schemas/trackers_response.json
@@ -6,9 +6,9 @@
       "type": "string",
       "description": "the tracker id that can be used for requesting info about a tracker"
     },
-    "tracking_code": {
+    "carrier_tracking_no": {
       "type": "string",
-      "description": "deprecated: will be renamed in `carrier_tracking_no`. tracking number (provided by the carrier) for this shipment"
+      "description": "tracking number (provided by the carrier) for this shipment"
     },
     "status": {
       "type": "string",
@@ -76,7 +76,7 @@
       }
     }
   },
-  "required": ["id", "tracking_code", "status", "created_at", "tracking_status_updated_at", "last_polling_at", "next_polling_at", "shipment_id", "carrier"],
+  "required": ["id", "carrier_tracking_no", "status", "created_at", "tracking_status_updated_at", "last_polling_at", "next_polling_at", "shipment_id", "carrier"],
   "additionalProperties": false,
   "definitions": {
     "address": {

--- a/_includes/trackers_get_response.json
+++ b/_includes/trackers_get_response.json
@@ -1,6 +1,6 @@
 {
   "id": "4a6922e2-09ad-4724-807c-7b4e572d3c6b",
-  "tracking_code": "723558934169",
+  "carrier_tracking_no": "723558934169",
   "status": "delivered",
   "created_at": "2015-07-20T09:35:23+02:00",
   "to": {

--- a/_includes/trackers_index_response.json
+++ b/_includes/trackers_index_response.json
@@ -2,7 +2,7 @@
   "trackers" : [
     {
       "id": "4a6922e2-09ad-4724-807c-7b4e572d3c6b",
-      "tracking_code": "723558934169",
+      "carrier_tracking_no": "723558934169",
       "to": {
         "company": null,
         "first_name": "Hans",
@@ -41,7 +41,7 @@
     },
     {
       "id": "5452ec46-560e-42ba-adf7-8a1b46d60ece",
-      "tracking_code": "JJD000390006125214950",
+      "carrier_tracking_no": "JJD000390006125214950",
       "to": {
         "company": null,
         "first_name": "Hans",

--- a/_includes/trackers_post_put_response.json
+++ b/_includes/trackers_post_put_response.json
@@ -1,6 +1,6 @@
 {
   "id": "4a6922e2-09ad-4724-807c-7b4e572d3c6b",
-  "tracking_code": "723558934169",
+  "carrier_tracking_no": "723558934169",
   "status": "registered",
   "created_at": "2015-07-20T09:35:23+02:00",
   "to": {


### PR DESCRIPTION
As previously stated, we've replaced the deprecated parameter `tracking_code` with `carrier_tracking_no`. Tracker objects are using this parameter from now on.