### PR TITLE
update carrier specific field lengths and getting started

### DIFF
--- a/_includes/concepts/carrier_specific_field_lengths_dhl.md
+++ b/_includes/concepts/carrier_specific_field_lengths_dhl.md
@@ -1,7 +1,7 @@
 * ```company``` 2 - 30 characters
-* ```last_name``` 1 - 30 characters (firstname + last_name < 30 characters)
+* ```last_name``` 1 - 30 characters (firstname + last_name <= 30 characters)
 * ```care_of``` 0 - 30 characters
-* ```street``` 1- 40 characters
+* ```street``` 1 - 40 characters
 * ```street_no``` 1 - 5 characters
 * ```zip_code``` 5 characters
 * ```city``` 1 - 50 characters

--- a/_includes/concepts/carrier_specific_field_lengths_dhl_express.md
+++ b/_includes/concepts/carrier_specific_field_lengths_dhl_express.md
@@ -1,0 +1,11 @@
+* ```company``` 2 - 35 characters
+* ```first_name``` + ```last_name``` 1 - 45 characters
+* ```care_of``` 0 - 35 characters
+* ```street``` 0 - 35 characters
+* ```street_no``` 0 - 15 characters
+* ```street``` + ```street_no``` 1 - 35 characters
+* ```zip_code``` 1 - 12 characters
+* ```city``` 1 - 35 characters
+* ```state``` 2 characters (for US only)
+* ```country``` 2 characters
+* ```phone``` 1 - 25 characters

--- a/_includes/concepts/carrier_specific_field_lengths_dpd.md
+++ b/_includes/concepts/carrier_specific_field_lengths_dpd.md
@@ -1,5 +1,6 @@
 * ```company``` 1 - 35 characters
 * ```first_name``` + ```last_name``` 1 - 35 characters
+* ```care_of``` 0 - 35 characters
 * ```street``` 1 - 35 characters
 * ```street_no``` 0 - 8 characters
 * ```zip_code``` 1 - 9 characters

--- a/_includes/concepts/carrier_specific_field_lengths_go.md
+++ b/_includes/concepts/carrier_specific_field_lengths_go.md
@@ -1,0 +1,9 @@
+* ```first_name``` + ```last_name``` 0 - 60 characters
+* ```company``` 2 - 60 characters
+* ```care_of``` 0 - 40 characters
+* ```street``` 1 - 35 characters
+* ```street_no``` 1 - 10 characters
+* ```zip_code``` 1 - 9 characters
+* ```city``` 1 - 30 characters
+* ```country``` 3 characters
+* ```phone``` 1 - 10 characters

--- a/_includes/concepts/carrier_specific_field_lengths_hermes_props.md
+++ b/_includes/concepts/carrier_specific_field_lengths_hermes_props.md
@@ -1,0 +1,9 @@
+* ```first_name``` 0 - 30 characters
+* ```last_name``` 1 - 25 characters
+* ```company``` 2 - 50 characters
+* ```care_of``` 0 - 50 characters
+* ```street``` 1 - 27 characters
+* ```street_no``` 0 - 5 characters
+* ```zip_code``` (country specific checks by carrier)
+* ```city``` 1 - 30 characters
+* ```country``` 3 characters

--- a/_includes/concepts/carrier_specific_field_lengths_tnt.md
+++ b/_includes/concepts/carrier_specific_field_lengths_tnt.md
@@ -1,0 +1,9 @@
+* ```first_name``` + ```last_name``` 1 - 25 characters
+* ```company``` 2 - 50 characters
+* ```care_of``` 0 - 30 characters
+* ```street``` + ```street_no``` 1 - 30 characters
+* ```zip_code``` 0 - 9 characters
+* ```city``` 1 - 30 characters
+* ```state``` 0 - 30 characters
+* ```country``` 3 characters
+* ```phone``` 4 - 16 characters (contactdialcode = 1 - 7 characters; contacttelephone = 1 - 9 characters)

--- a/concepts/index.md
+++ b/concepts/index.md
@@ -54,13 +54,13 @@ fail!
 Many API methods take optional parameters. For GET requests, any parameters not specified as a segment in the path can be passed as an HTTP query string parameter:
 
 {% highlight shell %}
-curl -i -u api_key "https://api.shipcloud.io/v1/shipments?service=returns"
+curl -i -u {{ site.apikey }}: "https://api.shipcloud.io/v1/shipments?service=returns"
 {% endhighlight %}
 
 For POST, PATCH, PUT, and DELETE requests, parameters not included in the URL should be encoded as JSON with a Content-Type of ‘application/json’:
 
 {% highlight shell %}
-curl -i -u f7ca956fd5670b2fa8fdee47672b2a26 -d '{"service":["returns"]}' "https://api.shipcloud.io/v1/shipments"
+curl -i -u {{ site.apikey }}: -H "Content-Type: application/json" -d '{"service":["returns"]}' "https://api.shipcloud.io/v1/shipments"
 {% endhighlight %}
 
 ## Versioning
@@ -151,13 +151,29 @@ correct according to the carrier.
 
 {% include concepts/carrier_specific_field_lengths_dhl.md %}
 
-### UPS
+### DHL Express
 
-{% include concepts/carrier_specific_field_lengths_ups.md %}
+{% include concepts/carrier_specific_field_lengths_dhl_express.md %}
+
+### GO!
+
+{% include concepts/carrier_specific_field_lengths_go.md %}
+
+### Hermes (ProPS)
+
+{% include concepts/carrier_specific_field_lengths_hermes_props.md %}
 
 ### MyDPD Pro / MyDPD Business
 
 {% include concepts/carrier_specific_field_lengths_dpd.md %}
+
+### TNT
+
+{% include concepts/carrier_specific_field_lengths_tnt.md %}
+
+### UPS
+
+{% include concepts/carrier_specific_field_lengths_ups.md %}
 
 ## Carrier specific label sizes
 Each carrier can provide label sizes in a specific DIN format. Here's an overview of the label

--- a/index.html
+++ b/index.html
@@ -44,16 +44,28 @@ layout: full
   </h2>
   <div class="row">
     <div class="col-md-12">
-      If you want to start testing our services fast - this is the way to go! First of all you
+      If you want to start testing our services fast - this is the way to go! Just follow these
+      simple steps:
+    </div>
+  </div>
+  <ol>
+    <li>
+      First of all you
       <a href="https://app.shipcloud.io/de/users/sign_up?plan=developer" target="_blank">
         register for our free developer plan.
       </a>
+    </li>
+    <li>
       Afterwards you can
       <a href="https://app.shipcloud.io/de/users/api_key" target="_blank">
         get your api keys from our backoffice
-      </a> and start implementing your first api call.
-    </div>
-  </div>
+      </a>
+    </li>
+    <li>
+      Start implementing your first api call using our
+      <a href="{{ site.baseurl }}/reference/#deleting-a-shipment">api reference</a>.
+    </li>
+  </ol>
   <h3>
     Integration guide
   </h3>


### PR DESCRIPTION
To make it easier for readers to start developing for/with shipcloud we've updated the `Getting started` section on our homepage to make it clear that it doesn't need more than 3 steps to get started.

We've also found some incorrect values for carrier specific field lengths. And since I was already working at these entries I've added values for TNT which were missing until now.