### PR TITLE
 add dhl customs declaration information

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -12,6 +12,12 @@ work with any other release modifiers than major versions.
 
 **Notice**: Not everything we do affects the viewable parts of our api.
 
+## [20180822] - 2018-08-22
+
+### Added
+- You can now supply [customs declaration data]({{ site.baseurl }}/examples/#dhl-customs-declaration)
+when creating a shipment and we will return the corresponding customs forms for the selected carrier.
+
 ## [20180814] - 2018-08-14
 
 ### Added

--- a/_includes/concepts/carrier_specific_field_lengths_dhl.md
+++ b/_includes/concepts/carrier_specific_field_lengths_dhl.md
@@ -8,3 +8,10 @@
 * ```state``` 0 - 30 characters
 * ```phone``` 0 - 20 characters
 * ```notification_email``` 0 - 70 characters
+* `customs_declaration`
+  * `contents_explanation` 0 - 256 characters
+  * `invoice_number` 0 - 35 characters
+  * `drop_off_location` 0 - 35 characters
+  * `items`
+    * `description` 0 - 256 characters
+    * `hs_tariff_number` 1 - 10 characters

--- a/_includes/navs/examples_nav.html
+++ b/_includes/navs/examples_nav.html
@@ -30,6 +30,7 @@
     <li><a href="#dhl-additional-insurance">DHL additional insurance</a></li>
     <li><a href="#ups-declared-value">UPS declared value</a></li>
     <li><a href="#dhl-bulk-shipments">DHL bulk shipments</a></li>
+    <li><a href="#dhl-customs-declaration">DHL customs declaration</a></li>
     <li><a href="#dpd-parcel-letter">DPD parcel letter</a></li>
     <li><a href="#deutsche-post-büchersendung">Deutsche Post Büchersendung</a></li>
     <li><a href="#deutsche-post-brief">Deutsche Post Brief</a></li>

--- a/_includes/reference/shipments_request_parameters.md
+++ b/_includes/reference/shipments_request_parameters.md
@@ -20,6 +20,24 @@ __Parameters:__
     - __earliest__ (datetime), timestamp describing the earliest time the carrier should pickup the shipment
     - __latest__ (datetime), timestamp describing the latest time the carrier should pickup the shipment
   - __pickup_address__ (object, optional), describes the pickup address. See [address request]({{ site.baseurl }}/reference/#addresses) for a detailed definition.
+- __customs_declaration__ (object, optional), customs declaration information
+  - __contents_type__ (string), type of shipment contents. Possible values are "commercial_goods", "commercial_sample", "documents", "gift", "returned_goods"
+  - __contents_explanation__ (string, optional), description of contents. Mandatory if contents_type is "commercial_goods". Max 256 characters, when using DHL as your carrier
+  - __currency__ (string), currency as uppercase ISO 4217 code
+  - __additional_fees__ (float, optional), additional custom fees to be payed
+  - __drop_off_location__ (string, optional), location where the package will be dropped of with the carrier
+  - __exporter_reference__ (string, optional), a note for the exporter
+  - __importer_reference__ (string, optional), a note for the importer
+  - __posting_date__ (string, optional), date of commital at carrier
+  - __invoice_number__ (string, optional), invoice number for the order
+  - __total_value_amount__ (float, optional), the overall value of the shipments' contents. Has to be between 0 and 1000
+  - __items__ (array), array of objects describing the items included in the shipments
+    - __origin_country__ (string), country as uppercase ISO 3166-1 alpha-2 code
+    - __description__ (string), a description of this item
+    - __hs_tariff_number__ (integer, optional), customs tariff number. See [wikipedia](https://en.wikipedia.org/wiki/Harmonized_System#Tariffs_by_region) for detailed information on region specific tariff numbers
+    - __quantity__ (integer), Number that defines how many items of this kind are in the shipment
+    - __value_amount__ (float), The total value for items of this kind
+    - __net_weight__ (float), Total weight for items of this kind
 - __reference_number__ (string, optional), a reference number (max. 30 characters) that you want this shipment to be identified with. You can use this afterwards to easier find the shipment in the shipcloud.io backoffice
 - __description__ (string), mandatory if you're using UPS and the following conditions are true: from and to countries are not the same; from and/or to countries are not in the EU; from and to countries are in the EU and the shipments service is not standard
 - __label__ (object, optional), define the DIN size the returned label should have. See [label size recipe]({{ site.baseurl }}/examples/#label-size) for detailed information

--- a/_includes/schemas/shipcloud.json
+++ b/_includes/schemas/shipcloud.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "shipment": {
+      "properties": {
+        "additional_services": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "enum": ["advance_notice", "cash_on_delivery", "drop_authorization", "saturday_delivery"],
+                "description": "key to identify the additional service"
+              },
+              "properties": {
+                "type": "object",
+                "properties": {
+                  "amount": { "type": "number" },
+                  "bank_code": { "type": "string" },
+                  "bank_name": { "type": "string" },
+                  "bank_account_holder": { "type": "string" },
+                  "bank_account_number": { "type": "string" },
+                  "reference1": {
+                    "type": "string",
+                    "description": "Text that should be displayed as the reason for transfer"
+                  },
+                  "currency": { "type": "string" },
+                  "email": { "type": "string" },
+                  "language": {
+                    "type": "string",
+                    "description": "language the customer should be notified in (ISO-639-1 format)"
+                  },
+                  "sms": { "type": "string" }
+                }
+              }
+            }
+          },
+          "required": ["name"],
+          "additionalProperties": false
+        },
+        "carrier": {
+          "type": "string",
+          "enum": ["dhl", "dpag", "dpd", "fedex", "gls", "go", "hermes", "iloxx", "tnt", "ups"],
+          "description": "acronym of the carrier you want to use"
+        },
+        "create_shipping_label": {
+          "type": "boolean",
+          "description": "determines if a shipping label should be created at the carrier (this means you will be charged when using the production api key)"
+        },
+        "description": {
+          "type": "string",
+          "description": "text that describes the contents of the shipment. This parameter is mandatory if you're using UPS and the following conditions are true: from and to countries are not the same; from and/or to countries are not in the EU; from and to countries are in the EU and the shipments service is not standard"
+        },
+        "from": {
+          "$ref": "#/definitions/address",
+          "description": "If missing, the default sender address (if defined in your shipcloud account) will be used"
+        },
+        "label": {
+          "$ref": "#/definitions/label",
+          "description": "label characteristics"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "here you can save additional data that you want to be associated with the shipment. Any combination of key-value pairs is possible",
+          "additionalProperties": true
+        },
+        "notification_email": {
+          "type": "string",
+          "description": "email address that we should notify once there's an update for this shipment"
+        },
+        "package": {
+          "$ref": "#/definitions/package"
+        },
+        "pickup": {
+          "$ref": "#/definitions/pickup",
+          "description": "pickup request for this shipment"
+        },
+        "reference_number": {
+          "type": "string",
+          "description": "a reference number (max. 30 characters) that you want this shipment to be identified with. You can use this afterwards to easier find the shipment in the shipcloud.io backoffice"
+        },
+        "service": {
+          "type": "string",
+          "enum": ["standard", "returns", "one_day", "one_day_early", "same_day"],
+          "default": "standard",
+          "description": "The service that should be used for the shipment. standard: The standard (ground) service for each carrier. returns: Returns service. one_day: express delivery. one_day_early: express delivery until 10am."
+        },
+        "to": {
+          "$ref": "#/definitions/address",
+          "description": "the receivers address"
+        }
+      },
+      "required": ["carrier", "package", "service", "to"],
+      "additionalProperties": false
+    }
+  },
+  "definitions": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "identifier of a previously created address"
+        },
+        "company": { "type": "string" },
+        "first_name": { "type": "string" },
+        "last_name": { "type": "string" },
+        "care_of": { "type": "string" },
+        "street": { "type": "string" },
+        "street_no": { "type": "string" },
+        "city": { "type": "string" },
+        "zip_code": { "type": "string" },
+        "state": { "type": "string" },
+        "country": { "type": "string", "description": "Country as uppercase ISO 3166-1 alpha-2 code" },
+        "phone": {
+          "type": "string",
+          "description": "telephone number (mandatory when using UPS and the following terms apply: service is one_day or one_day_early or ship to country is different than ship from country)"
+        }
+      },
+      "required": ["last_name", "street", "street_no", "city", "zip_code", "country"],
+      "additionalProperties": false
+    },
+    "label": {
+      "type": "object",
+      "properties": {
+        "size":  {
+          "type": "string",
+          "enum": ["A5", "A6"],
+          "description": "defines the DIN size that the returned label should have"
+        }
+      },
+      "additionalProperties": false,
+      "description": "label specific definitions"
+    },
+    "package": {
+      "type": "object",
+      "properties": {
+        "width":  { "type": "number" },
+        "height": { "type": "number" },
+        "length": { "type": "number" },
+        "weight": { "type": "number" },
+        "declared_value": {
+          "type": "object",
+          "description": "describing the value of the package contents",
+          "properties": {
+            "amount": { "type": "number" },
+            "currency": { "type": "string" }
+          }
+        },
+        "description": {
+          "type": "string",
+          "description": "text that describes the contents of the package. This parameter is mandatory if you're using UPS with service returns or DHL with service express"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["books", "bulk", "letter", "parcel", "parcel_letter"],
+          "description": "defines packages of being of a certain type - if no value is given, parcel will be used"
+        }
+      },
+      "required": ["width", "height", "length", "weight"],
+      "additionalProperties": false,
+      "description": "defines package dimensions"
+    },
+    "pickup": {
+      "type": "object",
+      "properties": {
+        "pickup_time": {
+          "type": "object",
+          "properties": {
+            "earliest": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "latest": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          "description": "defined time window when the carrier should pickup shipments",
+          "required": ["earliest", "latest"],
+          "additionalProperties": false
+        },
+        "pickup_address": {
+          "$ref": "#/definitions/address",
+          "description": "address where the shipment should be picked up"
+        }
+      },
+      "required": ["pickup_time"],
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "required": [ "shipment" ]
+}

--- a/_includes/schemas/shipments_request.json
+++ b/_includes/schemas/shipments_request.json
@@ -86,6 +86,94 @@
       "$ref": "#/definitions/pickup",
       "description": "pickup request for this shipment"
     },
+    "customs_declaration": {
+      "type": "object",
+      "description": "declaration of customs related information",
+      "properties": {
+        "contents_type": {
+          "type": "string",
+          "enum": ["commercial_goods", "commercial_sample", "documents", "gift", "returned_goods"],
+          "description": "Type of contents"
+        },
+        "contents_explanation": {
+          "type": "string",
+          "description": "description of contents. Mandatory if contents_type is 'commercial_goods. Max 256 characters, when using DHL as your carrier'"
+        },
+        "currency": {
+          "type": "string",
+          "description": "a valid ISO 4217 curreny code"
+        },
+        "additional_fees": {
+          "type": "number",
+          "description": "additional custom fees to be payed"
+        },
+        "drop_off_location": {
+          "type": "string",
+          "description": "location where the package will be dropped of with the carrier"
+        },
+        "exporter_reference": {
+          "type": "string",
+          "description": "a note for the exporter"
+        },
+        "importer_reference": {
+          "type": "string",
+          "description": "a note for the importer"
+        },
+        "posting_date": {
+          "type": "string",
+          "format": "date",
+          "description": "date of commital at carrier"
+        },
+        "invoice_number": {
+          "type": "string",
+          "description": "invoice number for the order"
+        },
+        "total_value_amount": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1000,
+          "description": "the overall value of the shipments' contents"
+        },
+        "items": {
+          "type": "array",
+          "description": "array of item objects",
+          "items": {
+            "type": "object",
+            "properties": {
+              "origin_country": {
+                "type": "string",
+                "description": "Country as uppercase ISO 3166-1 alpha-2 code"
+              },
+              "description": {
+                "type": "string",
+                "description": "a description of the item"
+              },
+              "hs_tariff_number": {
+                "type": "string",
+                "description": "customs tariff number. See https://en.wikipedia.org/wiki/Harmonized_System#Tariffs_by_region for detailed information on region specific tariff numbers",
+                "maxLength": 10
+              },
+              "quantity": {
+                "type": "integer",
+                "description": "Number that defines how many items of this kind are in the shipment"
+              },
+              "value_amount": {
+                "type": "string",
+                "description": "The total value for items of this kind"
+              },
+              "net_weight": {
+                "type": "number",
+                "description": "Total weight for items of this kind"
+              }
+            },
+            "required": ["origin_country", "description", "quantity", "value_amount", "net_weight"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["contents_type", "currency", "total_value_amount", "items"],
+      "additionalProperties": false
+    },
     "create_shipping_label": {
       "type": "boolean",
       "description": "determines if a shipping label should be created at the carrier (this means you will be charged when using the production api key)"

--- a/examples/index.md
+++ b/examples/index.md
@@ -795,6 +795,113 @@ POST https://api.shipcloud.io/v1/shipments
 }
 {% endhighlight %}
 
+## DHL customs declaration
+If you want to send a shipment to a country where a customs declaration is necessary you can specify
+this the following way. Detailed information about the parameters can be found in our
+[documentation of creating a shipment]({{ site.baseurl }}/reference/#shipments).
+
+__Requirements:__
+
+- ```customs_declaration.currency``` has to be _'EUR'_
+
+{% highlight http %}
+POST https://api.shipcloud.io/v1/shipments
+{% endhighlight %}
+
+{% highlight json %}
+{
+  "from": {
+    // see [1]
+  },
+  "to": {
+    // see [1]
+  },
+  "package": {
+    // see [2]
+  },
+  "customs_declaration": {
+    "contents_type": "commercial_goods",
+    "contents_explanation": "Alcoholic beverages",
+    "currency": "EUR",
+    "additional_fees": 0.0,
+    "drop_off_location": "DE",
+    "posting_date": "2017-10-07",
+    "invoice_number": "123ABC",
+    "total_value_amount": 247,
+    "items": [{
+        "origin_country": "DE",
+        "description": "Linkwood 25 years",
+        "hs_tariff_number": "501293884",
+        "quantity": "1",
+        "value_amount": "138.50",
+        "net_weight": "0.8"
+      },
+      {
+        "origin_country": "DE",
+        "description": "Caol Ila 18 years",
+        "hs_tariff_number": "123384890",
+        "quantity": "1",
+        "value_amount": "108.50",
+        "net_weight": "0.8"
+      }
+    ]
+  },
+  "carrier": "dhl",
+  "service": "standard",
+  "create_shipping_label": true
+}
+{% endhighlight %}
+
+#### Response
+
+{% highlight json %}
+{
+  "id": "199f803bf82fab79e17654213b61993fa78b0524",
+  "carrier": "dhl",
+  "carrier_tracking_no": "84168117830018",
+  "tracking_url": "https://track.shipcloud.io/de/199f803bf8",
+  "label_url": "https://sc-labels.s3.amazonaws.com/shipments/01370b4d/199f803bf8/label/shipping_label_199f803bf8.pdf",
+  "price": 10.7,
+  "customs_declaration": {
+    "id": "cd-f466905c",
+    "contents_type": "commercial_goods",
+    "contents_explanation": "Alcoholic beverages",
+    "invoice_number": "123ABC",
+    "drop_off_location": "DE",
+    "posting_date": "2017-10-07",
+    "additional_fees": "0.0",
+    "total_value_amount": "247.0",
+    "currency": "EUR",
+    "created_at": "2017-10-04T15:49:44+02:00",
+    "updated_at": "2017-10-04T15:49:44+02:00",
+    "carrier_declaration_document_url": "https://documents.shipcloud.io/shipments/519895c7165cdc032356d42c6d9babe8e3151473/customs_declaration_document.pdf",
+    "items": [{
+        "id": "cdi-50a46bf8",
+        "description": "Linkwood 25 years",
+        "hs_tariff_number": "501293884",
+        "net_weight": 0.8,
+        "origin_country": "DE",
+        "quantity": 1,
+        "value_amount": "138.5",
+        "created_at": "2017-10-04T15:49:44+02:00",
+        "updated_at": "2017-10-04T15:49:44+02:00"
+      },
+      {
+        "id": "cdi-081a523d",
+        "description": "Caol Ila 18 years",
+        "hs_tariff_number": "123384890",
+        "net_weight": 0.8,
+        "origin_country": "DE",
+        "quantity": 1,
+        "value_amount": "108.5",
+        "created_at": "2017-10-04T15:49:44+02:00",
+        "updated_at": "2017-10-04T15:49:44+02:00"
+      }
+    ]
+  }
+}
+{% endhighlight %}
+
 ## DPD parcel letter
 DPD defines [parcel letters](https://www.dpd.com/de_en/sending_parcels/our_shipping_services/parcelletter)
 as "everything which is too small for a parcel but larger and heavier than a classical letter"


### PR DESCRIPTION
We're now supporting one of the most requested features: customs declarations for DHL.
By simply adding a few more parameters when creating a shipment with a shipping label you'll also get the customs forms back and are able to send your shipments to non EU countries.