### PR TITLE
fix syntax error

### DIFF
--- a/_includes/schemas/trackers_response.json
+++ b/_includes/schemas/trackers_response.json
@@ -16,7 +16,8 @@
       "description": "key describing the current status"
     },
     "created_at": {
-      "type": "date-time",
+      "type": "string",
+      "format": "date-time",
       "description": "timestamp the tracker was created"
     },
     "from": {
@@ -24,15 +25,18 @@
       "description": "the senders address"
     },
     "tracking_status_updated_at": {
-      "type": "date-time",
+      "type": "string",
+      "format": "date-time",
       "description": "timestamp the tracking status was last updated"
     },
     "last_polling_at": {
-      "type": "date-time",
+      "type": "string",
+      "format": "date-time",
       "description": "timestamp the shipment status was last polled at the carrier"
     },
     "next_polling_at": {
-      "type": "date-time",
+      "type": "string",
+      "format": "date-time",
       "description": "timestamp the shipment status will be polled the next time"
     },
     "shipment_id": {
@@ -54,7 +58,8 @@
         "type": "object",
         "properties": {
           "timestamp": {
-            "type": "date-time",
+            "type": "string",
+            "format": "date-time",
             "description": "timestamp of when this event occured"
           },
           "location": {


### PR DESCRIPTION
Fixes "Error: Invalid type date-time in JSON Schema at schema#/properties/created_at."

In JSON Schema there is no such a type as `date-time`
http://json-schema.org/latest/json-schema-core.html#rfc.section.4.2

Both https://app.quicktype.io and http://www.jsonschema2pojo.org/ failed to create Java POJO from this schema because of this syntax error. After my changes the conversion is successful.