### PR TITLE
Added api endpoints for querying pickup requests

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -22,6 +22,8 @@ when creating a shipment and we will return the corresponding customs forms for 
 
 ### Added
 - More parameters to filter a [list of shipments]({{ site.baseurl }}/reference/#getting-a-list-of-shipments)
+- API endpoint to query [all pickup requests]({{ site.baseurl }}/reference/#getting-a-list-of-pickup-requests)
+- API endpoint to query the [details of a single pickup request]({{ site.baseurl }}/reference/#getting-information-about-a-pickup-request)
 
 ## [20180619] - 2018-06-19
 

--- a/_includes/navs/reference_nav.html
+++ b/_includes/navs/reference_nav.html
@@ -45,7 +45,9 @@
     <li>
       <a href="#pickup-requests">Pickup Requests</a>
       <ul class="nav">
-        <li><a href="#requesting-pickup">Requesting pickup</a></li>
+        <li><a href="#requesting-a-pickup">Create</a></li>
+        <li><a href="#getting-a-list-of-pickup-requests">Index</a></li>
+        <li><a href="#getting-information-about-a-pickup-request">Read</a></li>
       </ul>
     </li>
     <li>

--- a/_includes/pickup_requests_get_response.json
+++ b/_includes/pickup_requests_get_response.json
@@ -1,0 +1,35 @@
+{
+    "id": "c28a4ec0-e1ae-47a6-acae-1349ff0da52a",
+    "carrier": "dpd",
+    "carrier_pickup_number": "9380",
+    "shipments": [
+        {
+            "id": "604681675415e96052cf8fbaba78153a2e6d6bee"
+        },
+        {
+            "id": "11acaa0c4f251aaac4889d5f10329eb1aed80ff2"
+        },
+        {
+            "id": "9a5b91d766a523447c16897f8e20f4d7d06c25ca"
+        }
+    ],
+    "pickup_time": {
+        "earliest": "2018-07-30T09:00:00+02:00",
+        "latest": "2018-07-30T18:00:00+02:00"
+    },
+    "pickup_address": {
+        "company": "Muster-Company",
+        "first_name": "Max",
+        "last_name": "Mustermann",
+        "care_of": null,
+        "street": "Musterstraße",
+        "street_no": "42",
+        "zip_code": "22457",
+        "city": "Hamburg",
+        "state": null,
+        "country": "DE",
+        "phone": "555-555",
+        "email": null,
+        "id": "286daf26-c845-4dba-ae49-75582fbced00"
+    }
+}

--- a/_includes/pickup_requests_index_response.json
+++ b/_includes/pickup_requests_index_response.json
@@ -1,0 +1,61 @@
+{
+  "pickup_requests": [
+    {
+      "id": "123467a6-8e15-4a59-e145-0953f31c1196",
+      "carrier": "ups",
+      "carrier_pickup_number": "299A80MA91P",
+      "shipments": [
+        {
+          "id": "199f803bf82fab79e17654213b61993fa78b0524"
+        }, {
+          "id": "3a186c51d4281acbecf5ed38805b1db92a9d668b"
+        }
+      ],
+      "pickup_date": "2018/10/26",
+      "pickup_address": {
+        "company": "Weingut Fries",
+        "first_name": "Reiner u. Anke",
+        "last_name": "Fries",
+        "care_of": null,
+        "street": "Bachstraße",
+        "street_no": "66",
+        "zip_code": "56333",
+        "city": "Winningen",
+        "state": null,
+        "country": "DE",
+        "phone": "02606-2686",
+        "email": null,
+        "id": "a0a2406b-07c4-7df0-2ec6-07bcff92c4b8"
+      }
+    }, {
+      "id": "7342d2cc-416c-434f-a999-f7a845c64f1a",
+      "carrier": "dpd",
+      "carrier_pickup_number": "117639",
+      "shipments": [
+        {
+          "id": "86afb143f9c9c0cfd4eb7a7c26a5c616585a6271"
+        }, {
+          "id": "be81573799958587ae891b983aabf9c4089fc462"
+        }, {
+          "id": "be598a2fd27304cf2d82669b197517623629d94e"
+        }
+      ],
+      "pickup_date": "2018/10/23",
+      "pickup_address": {
+        "company": "Muster-Company",
+        "first_name": "Max",
+        "last_name": "Mustermann",
+        "care_of": null,
+        "street": "Musterstraße",
+        "street_no": "42",
+        "zip_code": "54321",
+        "city": "Musterstadt",
+        "state": null,
+        "country": "DE",
+        "phone": "555-555",
+        "email": null,
+        "id": "522a7cb1-d6c8-418c-ac26-011127ab5bbe"
+      }
+    }
+  ]
+}

--- a/_includes/schemas/pickup_requests_response.json
+++ b/_includes/schemas/pickup_requests_response.json
@@ -10,6 +10,10 @@
       "type": "string",
       "description": "carrier used for this pickup request"
     },
+    "carrier_pickup_number": {
+      "type": "string",
+      "description": "carrier identifier for this pickup request"
+    },
     "pickup_time": {
       "type": "object",
       "properties": {
@@ -34,22 +38,57 @@
           "type": "string",
           "description": "identifier of a previously created address"
         },
-        "company": { "type": "string" },
-        "first_name": { "type": "string" },
-        "last_name": { "type": "string" },
-        "care_of": { "type": "string" },
-        "street": { "type": "string" },
-        "street_no": { "type": "string" },
-        "city": { "type": "string" },
-        "zip_code": { "type": "string" },
-        "state": { "type": "string" },
-        "country": { "type": "string", "description": "Country as uppercase ISO 3166-1 alpha-2 code" },
+        "company": {
+          "type": "string"
+        },
+        "first_name": {
+          "type": "string"
+        },
+        "last_name": {
+          "type": "string"
+        },
+        "care_of": {
+          "type": "string"
+        },
+        "street": {
+          "type": "string"
+        },
+        "street_no": {
+          "type": "string"
+        },
+        "city": {
+          "type": "string"
+        },
+        "zip_code": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string",
+          "description": "Country as uppercase ISO 3166-1 alpha-2 code"
+        },
         "phone": {
           "type": "string",
           "description": "telephone number (mandatory when using UPS and the following terms apply: service is one_day or one_day_early or ship to country is different than ship from country)"
         }
       },
       "required": ["last_name", "street", "street_no", "city", "zip_code", "country"],
+      "additionalProperties": false
+    },
+    "shipments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "id of the shipment included in this pickup request"
+          }
+        }
+      },
+      "required": ["id"],
       "additionalProperties": false
     }
   },

--- a/reference/index.md
+++ b/reference/index.md
@@ -128,7 +128,7 @@ If you want to create a shipment, this is the way to go!
 no payload
 {% endhighlight %}
 
-You can filter the shipments list by using one or more of the following GET parameters. 
+You can filter the shipments list by using one or more of the following GET parameters.
 
 {% include reference/shipments_index_request_togglebox.html %}
 
@@ -338,7 +338,7 @@ With this call you can find out how much a specific package will cost you.
 
 ## Pickup requests
 
-### Requesting pickup
+### Requesting a pickup
 There are two ways you can request shipments to be picked up by a specific carrier. By simply
 stating that all shipments that haven't been picked up already should be picked up or by specifying
 which shipments should by picked up.
@@ -396,6 +396,42 @@ account for picking up shipments. In those cases we'll return ```null``` as pick
 {% include headers/200_ok.html %}
 {% highlight json %}
 {% include pickup_post_requests_response.json %}
+{% endhighlight %}
+
+<i class="glyphicon glyphicon-arrow-right"></i> JSON schema: [Pickup Requests response]({{ site.baseurl }}/reference/pickup_requests_response_schema.html)
+
+### Getting a list of pickup requests
+
+#### Request
+
+<kbd>GET</kbd> __/v1/pickup_requests__
+
+{% highlight shell %}
+no payload
+{% endhighlight %}
+
+#### Response
+
+{% include headers/200_ok.html %}
+{% highlight json %}
+{% include pickup_requests_index_response.json %}
+{% endhighlight %}
+
+### Getting information about a pickup request
+
+#### Request
+
+<kbd>GET</kbd> __/v1/pickup_requests/:id__
+
+{% highlight shell %}
+no payload
+{% endhighlight %}
+
+#### Response
+
+{% include headers/200_ok.html %}
+{% highlight json %}
+{% include pickup_requests_get_response.json %}
 {% endhighlight %}
 
 <i class="glyphicon glyphicon-arrow-right"></i> JSON schema: [Pickup Requests response]({{ site.baseurl }}/reference/pickup_requests_response_schema.html)


### PR DESCRIPTION
If you want to know more about the separate pickup requests you've made you can now query our api to get a list of all of your pickup requests (`GET /v1/pickup_requests`) or details about a single one pickup_request (`GET /v1/pickup_requests/:id`)