### PR TITLE
Developer portal add mrn in openapi spec

### DIFF
--- a/_includes/reference/shipments_request_parameters.html
+++ b/_includes/reference/shipments_request_parameters.html
@@ -127,9 +127,6 @@
         <strong>additional_fees</strong> (float, optional), additional custom fees to be payed
       </li>
       <li>
-        <strong>movement_reference_number</strong> (string, optional), the movement reference number (MRN)
-      </li>
-      <li>
         <strong>drop_off_location</strong> (string, optional), location where the package will be
         dropped of with the carrier
       </li>
@@ -138,6 +135,9 @@
       </li>
       <li>
         <strong>importer_reference</strong> (string, optional), a note for the importer
+      </li>
+      <li>
+        <strong>movement_reference_number</strong> (string, optional), the movement reference number (MRN)
       </li>
       <li>
         <strong>posting_date</strong> (string, optional), date of commital at carrier

--- a/_includes/reference/shipments_request_parameters.html
+++ b/_includes/reference/shipments_request_parameters.html
@@ -127,6 +127,9 @@
         <strong>additional_fees</strong> (float, optional), additional custom fees to be payed
       </li>
       <li>
+        <strong>movement_reference_number</strong> (string, optional), the movement reference number (MRN)
+      </li>
+      <li>
         <strong>drop_off_location</strong> (string, optional), location where the package will be
         dropped of with the carrier
       </li>

--- a/_includes/schemas/shipments_request.json
+++ b/_includes/schemas/shipments_request.json
@@ -194,10 +194,6 @@
           "type": "number",
           "description": "additional custom fees to be payed"
         },
-        "movement_reference_number": {
-          "type": "string",
-          "description": "the movement reference number (MRN)"
-        },
         "drop_off_location": {
           "type": "string",
           "description": "location where the package will be dropped of with the carrier"
@@ -209,6 +205,10 @@
         "importer_reference": {
           "type": "string",
           "description": "a note for the importer"
+        },
+        "movement_reference_number": {
+          "type": "string",
+          "description": "the movement reference number (MRN)"
         },
         "posting_date": {
           "type": "string",

--- a/_includes/schemas/shipments_request.json
+++ b/_includes/schemas/shipments_request.json
@@ -194,6 +194,10 @@
           "type": "number",
           "description": "additional custom fees to be payed"
         },
+        "movement_reference_number": {
+          "type": "string",
+          "description": "the movement reference number (MRN)"
+        },
         "drop_off_location": {
           "type": "string",
           "description": "location where the package will be dropped of with the carrier"

--- a/_includes/schemas/shipments_response.json
+++ b/_includes/schemas/shipments_response.json
@@ -146,10 +146,6 @@
           "type": "number",
           "description": "additional custom fees to be payed"
         },
-        "movement_reference_number": {
-          "type": "string",
-          "description": "the movement reference number (MRN)"
-        },
         "carrier_declaration_document_url": {
           "type": "string",
           "description": "URL where you can download the customs declaration in pdf format"
@@ -243,6 +239,10 @@
             "required": ["origin_country", "description", "quantity", "value_amount", "net_weight"],
             "additionalProperties": false
           }
+        },
+        "movement_reference_number": {
+          "type": "string",
+          "description": "the movement reference number (MRN)"
         },
         "posting_date": {
           "type": "string",

--- a/_includes/schemas/shipments_response.json
+++ b/_includes/schemas/shipments_response.json
@@ -146,6 +146,10 @@
           "type": "number",
           "description": "additional custom fees to be payed"
         },
+        "movement_reference_number": {
+          "type": "string",
+          "description": "the movement reference number (MRN)"
+        },
         "carrier_declaration_document_url": {
           "type": "string",
           "description": "URL where you can download the customs declaration in pdf format"

--- a/downloads/api/oai/shipcloud_v1_oai3.json
+++ b/downloads/api/oai/shipcloud_v1_oai3.json
@@ -3791,11 +3791,11 @@
             "contents_explanation": "Alcoholic beverages",
             "invoice_number": "123ABC",
             "drop_off_location": "DE",
+            "movement_reference_number": "AAA111",
             "posting_date": "2024-08-27",
             "additional_fees": 1.22,
             "total_value_amount": 247.31,
-            "currency": "EUR",
-            "movement_reference_number": "AAA111"
+            "currency": "EUR"
           },
           "carrier": "dhl",
           "service": "standard",
@@ -3861,11 +3861,11 @@
             "contents_explanation": "Alcoholic beverages",
             "invoice_number": "123ABC",
             "drop_off_location": "DE",
+            "movement_reference_number": "AAA111",
             "posting_date": "2024-08-27",
             "additional_fees": 1.22,
             "total_value_amount": 247.31,
-            "currency": "EUR",
-            "movement_reference_number": "AAA111"
+            "currency": "EUR"
           },
           "carrier": "ups",
           "service": "standard",
@@ -4038,11 +4038,11 @@
             "contents_explanation": "Alcoholic beverages",
             "invoice_number": "123ABC",
             "drop_off_location": "DE",
+            "movement_reference_number": "AAA111",
             "posting_date": "2024-08-27",
             "additional_fees": 1.22,
             "total_value_amount": 247.31,
             "currency": "EUR",
-            "movement_reference_number": "AAA111",
             "created_at": "2024-08-27T17:13:12+02:00",
             "updated_at": "2024-08-27T17:13:12+02:00",
             "carrier_declaration_document_url": "https://documents.shipcloud.io/shipments/519895c7165cdc032356d42c6d9babe8e3151473/customs_declaration_document.pdf",
@@ -4130,11 +4130,11 @@
             "contents_explanation": "Alcoholic beverages",
             "invoice_number": "123ABC",
             "drop_off_location": "DE",
+            "movement_reference_number": "AAA111",
             "posting_date": "2024-08-27",
             "additional_fees": 1.22,
             "total_value_amount": 247.31,
             "currency": "EUR",
-            "movement_reference_number": "AAA111",
             "created_at": "2024-08-27T17:13:12+02:00",
             "updated_at": "2024-08-27T17:13:12+02:00",
             "carrier_declaration_document_url": "https://documents.shipcloud.io/shipments/519895c7165cdc032356d42c6d9babe8e3151473/customs_declaration_document.pdf",
@@ -4747,10 +4747,6 @@
             "type": "number",
             "description": "additional custom fees to be payed"
           },
-          "movement_reference_number": {
-            "type": "string",
-            "description": "the movement reference number (MRN)"
-          },
           "drop_off_location": {
             "type": "string",
             "description": "location where the package will be dropped of with the carrier"
@@ -4762,6 +4758,10 @@
           "importer_reference": {
             "type": "string",
             "description": "a note for the importer"
+          },
+          "movement_reference_number": {
+            "type": "string",
+            "description": "the movement reference number (MRN)"
           },
           "posting_date": {
             "type": "string",

--- a/downloads/api/oai/shipcloud_v1_oai3.json
+++ b/downloads/api/oai/shipcloud_v1_oai3.json
@@ -3562,7 +3562,8 @@
             "posting_date": "2024-08-27",
             "additional_fees": 1.22,
             "total_value_amount": 247.31,
-            "currency": "EUR"
+            "currency": "EUR",
+            "movement_reference_number": "AAA111"
           },
           "carrier": "dhl",
           "service": "standard",
@@ -3631,7 +3632,8 @@
             "posting_date": "2024-08-27",
             "additional_fees": 1.22,
             "total_value_amount": 247.31,
-            "currency": "EUR"
+            "currency": "EUR",
+            "movement_reference_number": "AAA111"
           },
           "carrier": "ups",
           "service": "standard",
@@ -3808,6 +3810,7 @@
             "additional_fees": 1.22,
             "total_value_amount": 247.31,
             "currency": "EUR",
+            "movement_reference_number": "AAA111",
             "created_at": "2024-08-27T17:13:12+02:00",
             "updated_at": "2024-08-27T17:13:12+02:00",
             "carrier_declaration_document_url": "https://documents.shipcloud.io/shipments/519895c7165cdc032356d42c6d9babe8e3151473/customs_declaration_document.pdf",
@@ -3899,6 +3902,7 @@
             "additional_fees": 1.22,
             "total_value_amount": 247.31,
             "currency": "EUR",
+            "movement_reference_number": "AAA111",
             "created_at": "2024-08-27T17:13:12+02:00",
             "updated_at": "2024-08-27T17:13:12+02:00",
             "carrier_declaration_document_url": "https://documents.shipcloud.io/shipments/519895c7165cdc032356d42c6d9babe8e3151473/customs_declaration_document.pdf",
@@ -4540,6 +4544,10 @@
           "additional_fees": {
             "type": "number",
             "description": "additional custom fees to be payed"
+          },
+          "movement_reference_number": {
+            "type": "string",
+            "description": "the movement reference number (MRN)"
           },
           "drop_off_location": {
             "type": "string",


### PR DESCRIPTION
Add new field `shipment.customs_declaration.movement_reference_number` to docs for:
* `POST`/shipments
* `GET`/shipments
* `GET`/shipments/{id}

https://app.shortcut.com/shipcloud/story/41226/developer-portal-add-mrn-in-openapi-spec